### PR TITLE
README updates and copy edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For Vertica on Kubernetes containers and resources, see [vertica-kubernetes](htt
 
 ## [One-Node CE](https://github.com/vertica/vertica-containers/tree/main/one-node-ce)
 
-This directory provides instructions for building the containerized version of the [Vertica Community Edition (CE)](https://www.vertica.com/landing-page/start-your-free-trial-today/), a free, limited license that Vertica provides users so that they can get a hands-on introduction to the platform. For an overview, see the [Vertica documentation](https://www.vertica.com/docs/latest/HTML/Content/Authoring/GettingStartedGuide/DownloadingAndStartingVM/DownloadingAndStartingVM.htm).
+The One-Node CE directory gives instructions to build the containerized version of the [Vertica Community Edition (CE)](https://www.vertica.com/landing-page/start-your-free-trial-today/), a free, limited license that Vertica provides users as a hands-on introduction to the platform. For an overview, see the [Vertica documentation](https://www.vertica.com/docs/latest/HTML/Content/Authoring/GettingStartedGuide/DownloadingAndStartingVM/DownloadingAndStartingVM.htm).
 
 To build the One-Node CE, you must have a a licensed Vertica RPM or .deb file.
 
@@ -17,13 +17,13 @@ Vertica publishes the binary version of this container on [DockerHub](https://hu
 
 ## [UDx-container](https://github.com/vertica/vertica-containers/tree/main/UDx-container)
 
-This directory packages in a container the following resources required to build User-Defined eXtensions:
+The UDx-container directory packages in a container the following resources required to build User-Defined eXtensions:
 - C++-compiler
 - Libraries
 - Google protobuf compiler
 - Python interpreter
 - Tools to invoke the UDx
 
-As noted above, to build and install this container you need a copy of the Vertica RPM (or Vertica .deb file used at your site for your Vertica installation.
+As noted above, to build and install this container you need a copy of the Vertica RPM or .deb file used at your site for your Vertica installation.
 
 To build the UDx-container, you must have a a licensed Vertica RPM or .deb file.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,29 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
 
-# Vertica containers
+# Vertica Containers
 
-This repository has the sources for some container-based projects using Vertica
-(other than the containers used in
-[vertica-kubernetes](https://github.com/vertica/vertica-kubernetes),
-which has its own repository).
+This repository has the sources for container-based projects using Vertica.
 
-These containers are incomplete in themselves: at the moment (November
-2021) they require a licensed Vertica RPM or .deb file to build.
+For Vertica on Kubernetes containers and resources, see [vertica-kubernetes](https://github.com/vertica/vertica-kubernetes).
 
-## [One-Node "CE"](https://github.com/vertica/vertica-containers/tree/main/one-node-ce)
+## [One-Node CE](https://github.com/vertica/vertica-containers/tree/main/one-node-ce)
 
-This directory gives the instructions for building the containerized
-version of our Community Edition
-virtual-machine-based [Community Edition (CE)](https://www.vertica.com/landing-page/start-your-free-trial-today/).
+This directory provides instructions for building the containerized version of the [Vertica Community Edition (CE)](https://www.vertica.com/landing-page/start-your-free-trial-today/), a free, limited license that Vertica provides users so that they can get a hands-on introduction to the platform. For an overview, see the [Vertica documentation](https://www.vertica.com/docs/latest/HTML/Content/Authoring/GettingStartedGuide/DownloadingAndStartingVM/DownloadingAndStartingVM.htm).
 
-As noted above, to build and install this container you need a Vertica RPM (or Vertica
-.deb file).  However, do not despair!  We also publish a binary version of this
-container, see our [Vertica Dockerhub vertica-ce download](https://hub.docker.com/r/vertica/vertica-ce).
+To build the One-Node CE, you must have a a licensed Vertica RPM or .deb file.
+
+Vertica publishes the binary version of this container on [DockerHub](https://hub.docker.com/u/vertica) as the [vertica/vertica-ce](https://hub.docker.com/r/vertica/vertica-ce) container.
+
 
 ## [UDx-container](https://github.com/vertica/vertica-containers/tree/main/UDx-container)
 
-This container packages the pieces needed to build User-Defined
-eXtensions --- C++-compiler, libraries, the appropriate version of the Google protobuf compiler,
-Python interpreter, and tools to invoke them.  As noted above, to build and install this container you need a copy of the Vertica RPM (or Vertica .deb file) used at your site for your Vertica installation.
+This directory packages in a container the following resources required to build User-Defined eXtensions:
+- C++-compiler
+- Libraries
+- Google protobuf compiler
+- Python interpreter
+- Tools to invoke the UDx
 
+As noted above, to build and install this container you need a copy of the Vertica RPM (or Vertica .deb file used at your site for your Vertica installation.
+
+To build the UDx-container, you must have a a licensed Vertica RPM or .deb file.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This repository has the sources for container-based projects using Vertica.
 
 For Vertica on Kubernetes containers and resources, see [vertica-kubernetes](https://github.com/vertica/vertica-kubernetes).
 
+> **IMPORTANT**: To build the projects in this repository, you must have a licensed Vertica RPM or DEB file.
+
 ## [One-Node CE](https://github.com/vertica/vertica-containers/tree/main/one-node-ce)
 
-The One-Node CE directory gives instructions to build the containerized version of the [Vertica Community Edition (CE)](https://www.vertica.com/landing-page/start-your-free-trial-today/), a free, limited license that Vertica provides users as a hands-on introduction to the platform. For an overview, see the [Vertica documentation](https://www.vertica.com/docs/latest/HTML/Content/Authoring/GettingStartedGuide/DownloadingAndStartingVM/DownloadingAndStartingVM.htm).
-
-To build the One-Node CE, you must have a a licensed Vertica RPM or .deb file.
+The One-Node CE directory provides instructions to build the containerized version of the [Vertica Community Edition (CE)](https://www.vertica.com/landing-page/start-your-free-trial-today/), a free, limited license that Vertica provides users as a hands-on introduction to the platform. For an overview, see the [Vertica documentation](https://www.vertica.com/docs/latest/HTML/Content/Authoring/GettingStartedGuide/DownloadingAndStartingVM/DownloadingAndStartingVM.htm).
 
 Vertica publishes the binary version of this container on [DockerHub](https://hub.docker.com/u/vertica) as the [vertica/vertica-ce](https://hub.docker.com/r/vertica/vertica-ce) container.
 
@@ -23,7 +23,3 @@ The UDx-container directory packages in a container the following resources requ
 - Google protobuf compiler
 - Python interpreter
 - Tools to invoke the UDx
-
-As noted above, to build and install this container you need a copy of the Vertica RPM or .deb file used at your site for your Vertica installation.
-
-To build the UDx-container, you must have a a licensed Vertica RPM or .deb file.

--- a/UDx-container/README.md
+++ b/UDx-container/README.md
@@ -59,7 +59,7 @@ For example, you might build multiple containers to develop UDxs for multiple Ve
 
 ## Building with a canonically-named Vertica binary
 
-The build process requires the Vertica version. The makefile can extract this information automatically from a canonically-named RPM or DEB file in one of the following formats:
+The build process requires the Vertica version. The `makefile` can extract this information automatically from a canonically-named RPM or DEB file in one of the following formats:
 
 ```shell
 $ vertica-10.1.1-5.x86_64.RHEL6.rpm
@@ -69,7 +69,7 @@ $ vertica-10.1.1-5.x86_64.RHEL6.rpm
 $ vertica_10.0.1-5_amd64.deb
 ```
 
-The makefile extracts the Vertica version (10.1.1-5) and the OS distribution version (RHEL 6). If the Vertica binary uses this format, run `make` with the `TARGET` variable to build the container. For example, the following command builds a UDx container with a canonically-named RPM file:
+The `makefile` extracts the Vertica version (10.1.1-5) and the OS distribution version (RHEL 6). If the Vertica binary uses this format, run `make` with the `TARGET` variable to build the container. For example, the following command builds a UDx container with a canonically-named RPM file:
 
 ```shell
 $ make TARGET=rpm
@@ -167,18 +167,18 @@ In the previous diagram:
 
 ## Making your UDx accessible to the test Vertica server
 
-Start the server in your UDx working directory. This provides the container for the test Vertica server a path to your UDx working directory when it starts and it mounts its current working directory. The Vertica in the container runs as `dbadmin`.
+Start the server in your UDx working directory. This provides the test Vertica server container a path to your UDx working directory when it starts and so that it can mount its current working directory. The Vertica in the container runs as `dbadmin`.
 
 
 ## Starting the test Vertica server
 
 In addition to the tools such as `vsdk-make` and `vsdk-g++`, there is a `vsdk-vertica` command that creates a scratch Vertica server so you can test your UDx.
 
-The UDx container itself is not writable, so it creates and mounts a Docker volume called `verticasdk-data`. It also mounts the current working directory and your home directory in the container using the same names those directories have on the host machine. In addition, `vsdk-vertica` understands the `VSDK_MOUNT` and `VSDK_ENV` environment variables described in [environment variable](#environment-variables).
+The UDx container itself is not writable, so it creates and mounts a Docker volume called `verticasdk-data`. It also mounts the current working directory and your home directory in the container using the same names those directories have on the host machine. In addition, `vsdk-vertica` understands the `VSDK_MOUNT` and `VSDK_ENV` environment variables described in [environment variables](#environment-variables).
 
-`vsdk-vertica` launches a server that runs in the background in a container named `verticasdk`.  You can read the container log using the `docker logs` command.
+## Fetching the test Vertica server startup log
 
-## The test Vertica server startup log
+`vsdk-vertica` launches a server that runs in the background in a container named `verticasdk`.  You can read the container log using the `docker logs` command:
 
 ```shell
 docker logs verticasdk
@@ -186,18 +186,18 @@ docker logs verticasdk
 
 ## Stopping and removing the test Vertica server
 
-When you are done using the container, you can stop it:
+When you are done using the container, use `docker stop` to stop it:
 
 ```shell
 docker stop verticasdk
 ```
-and remove it:
+Use `docker rm` to remove it:
 
 ```shell
 docker rm verticasdk
 ```
 
-When you are done with the container, it is probably a good idea to also remove the Docker volume it mounts as a scratch database:
+When you are done with the container, it is recommended that you also remove the Docker volume it mounts as a scratch database:
 
 ```shell
 docker volume rm verticasdk-data
@@ -205,7 +205,7 @@ docker volume rm verticasdk-data
 
 ## Loading your UDx into the test Vertica server
 
-When the test Vertica server is ready, you can use `vsql` to load the UDx. The following command loads the `AggregateFunctions` library and execute some functions from it:
+When the test Vertica server is ready, you can use `vsql` to load the UDx. The following commands load the `AggregateFunctions` library and execute some functions from it:
 
 ```shell
 $ cd tmp-test/examples
@@ -217,7 +217,7 @@ For additional details about working with UDx libraries, see [User-Defined Exten
 
 # Testing the container
 
-(This section describes testing the UDx container after you've modified the container (i.e., something in this repository).  For testing your UDx, see [Testing your UDx](#testing-your-udx).)
+> **NOTE**: This section describes testing the UDx container after you modified the container with any of the tools in this repository. For testing your UDx, see [Testing your UDx](#testing-your-udx).
 
 The `make test` target calls a few `vsdk-*` scripts to test that your container was built correctly. Then, it mounts the following directories in the UDx container filesystem to replicate your local development environment:
 - `/home/<user-name>`
@@ -232,4 +232,4 @@ Run `make test` with the `TARGET` environment variable:
 ```shell
 $ make test TARGET=deb
 ```
-> **NOTE**: The scripts need to know the tag for the container, which is derived from the VERTICA_VERSION environment variable.  If you have a canonically-named RPM or .deb, the makefile knows how to extract the VERTICA_VERSION from the filename, otherwise you will have to specify it, just as you did when you created the container.
+> **NOTE**: The scripts need to know the tag for the container, which is derived from the VERTICA_VERSION environment variable.  If you have a canonically-named RPM or DEB, the makefile knows how to extract the VERTICA_VERSION from the filename, otherwise you will have to specify it, just as you did when you created the container.

--- a/UDx-container/README.md
+++ b/UDx-container/README.md
@@ -14,25 +14,25 @@ For additional details about developing Vertica UDxs, see [Extending Vertica](ht
 - vsql driver and other applicable [client libraries](https://www.vertica.com/download/vertica/client-drivers/).
 - [Python 3](https://www.python.org/downloads/).
 
-## Supported Platforms
+# Supported Platforms
 
 Container techology provides the freedom to run environments independently of the host operating system. For example, you can run a CentOS container on an Ubuntu workstation, and vice versa.
 
 Vertica provides a Dockerfile for different distributions so that you can create an containerized development environment that matches your production environment.
 
-### Vertica:
+## Vertica:
 Vertica tests the following versions, but the contents of this repository might work with eariler versions:
 - 10.x
 - 11.x
 
-### CentOS
+## CentOS
 - 7.9
 
-### Ubuntu
+## Ubuntu
 - 18.04
 - 20.04
 
-## Overview
+# Overview
 
 The Vertica UDx container packages the binaries, libraries, and compilers required to create C++ Vertica UDx extensions. Use this repository with your Vertica binary to develop UDxs on any host system that meets the [Prerequisites](#prerequisites).
 
@@ -40,11 +40,11 @@ In addition, this repository provides `vsdk-*` commmand line tools to simplify t
 
 Of special note is the `vsdk-vertica` command which launches a container with a Vertica executing within it.  You can use this container to load and test your UDx.
 
-## Building the UDx container
+# Building the UDx container
 
 Use the repository `makefile` to build your container. The makefile requires that you store a Vertica RPM or DEB file in the top-level directory of your cloned repository. The container inherits the privileges and user ID from the user executing the container.
 
-### Build variables
+## Build variables
 
 You can include build variables in the build process to customize the container. The following table describes the available variables:
 
@@ -57,7 +57,7 @@ You can include build variables in the build process to customize the container.
 
 For example, you might build multiple containers to develop UDxs for multiple Vertica versions. To help distinguish between containers, define `OSTAG` and `VERTICA_VERSION` in the build command. If you set `OSTAG=centos` and `VERTICA_VERSION=11.0.0-0`, the full container specification is `verticasdk:centos-11.0.0-0`.
 
-### Building with a canonically-named Vertica binary
+## Building with a canonically-named Vertica binary
 
 The build process requires the Vertica version. The makefile can extract this information automatically from a canonically-named RPM or DEB file in one of the following formats:
 
@@ -75,7 +75,7 @@ The makefile extracts the Vertica version (10.1.1-5) and the OS distribution ver
 $ make TARGET=rpm
 ```
 
-### Building with variables
+## Building with variables
 
 If the RPM or DEB file does not use the canonical-naming convention, define the `VERTICA_VERSION` variable in the make command:
 
@@ -83,7 +83,7 @@ If the RPM or DEB file does not use the canonical-naming convention, define the 
 $ make TARGET=deb VERTICA_VERSION=11.0.0-0
 ```
 
-## Developing UDxs
+# Developing UDxs
 
 This repository provides `vsdk-*` scripts to help you test and compile your UDx in a multi-environment compilation. You invoke the following scripts on your host machine, and they execute in the UDx container:
 
@@ -98,9 +98,11 @@ This repository provides `vsdk-*` scripts to help you test and compile your UDx 
 
 These scripts use the contents of `/etc/os-release` to determine whether the container has a `centos` or `ubuntu` tag. If your host uses a different distribution than your development environment, you can edit `vsdk-bash` directly to change the default setting. Alternatively, you can change the default interactively by defining the OSTAG [environment variable](#environment-variables) when you execute `vsdk-make`:
 
-`OSTAG=ubuntu vsdk-make`
+```shell
+$ OSTAG=ubuntu vsdk-make
+```
 
-### Environment variables
+## Environment variables
 
 Use environment variables to provide additional information to the `vsdk-*` commands. The following table defines the avaiable environment variables:
 
@@ -111,7 +113,7 @@ Use environment variables to provide additional information to the `vsdk-*` comm
 | VSDK_ENV | Optional file that defines environment variables for `vsdk-*` commands that run in the container. For formatting details, see [Declare default environment variables in file](https://docs.docker.com/compose/env-file/) in the Docker documentation.|
 | VSDK_MOUNT | A list of one or more directories that you want to mount in the UDx container filesystem. To mount multiple directories, separate each path with a space. For additional details, see [Mounting additional files](#mounting-additional-files). |
 
-### Compiling UDxs
+## Compiling UDxs
 
 After you [test your UDx container](#testing-the-container), you can develop UDxs in the current working directory on the host machine and compile them in the UDx container. Use the `vsdk-make` script to execute your makefile and compile your UDx. In a new environment, `vsdk-make` mounts the same directories as the `make test` command.
 
@@ -121,7 +123,7 @@ The following command passes a file containing [environment variables](#environm
 $ VSDK_ENV=env-vars vsdk-make
 ```
 
-### Mounting additional files 
+## Mounting additional files 
 
 `vsdk-make` mounts the current working directory and its child directories in the container filesystem. In some circumstances, your compilation process might require additional files that are not available in the mounted directories. 
 
@@ -139,7 +141,7 @@ You can also use `VSDK_MOUNT` with the `make test` command:
 $ VSDK_MOUNT='/usr/share/lib /usr/share/toolB' make test
 ```
 
-### Host and container filesystem views
+## Host and container filesystem views
 
 By default, the UDx container contains the following directories:
 - `/bin`
@@ -161,14 +163,14 @@ In the previous diagram:
    $ VSDK_MOUNT='/usr/share/lib /usr/share/vtoolB' vsdk-make
    ```
 
-## Loading the UDx into a test Vertica server
+# Loading the UDx into a test Vertica server
 
-### Making your UDx accessible to the test Vertica server
+## Making your UDx accessible to the test Vertica server
 
 Start the server in your UDx working directory. This provides the container for the test Vertica server a path to your UDx working directory when it starts and it mounts its current working directory. The Vertica in the container runs as `dbadmin`.
 
 
-### Starting the test Vertica server
+## Starting the test Vertica server
 
 In addition to the tools such as `vsdk-make` and `vsdk-g++`, there is a `vsdk-vertica` command that creates a scratch Vertica server so you can test your UDx.
 
@@ -176,13 +178,13 @@ The UDx container itself is not writable, so it creates and mounts a Docker volu
 
 `vsdk-vertica` launches a server that runs in the background in a container named `verticasdk`.  You can read the container log using the `docker logs` command.
 
-#### The test Vertica server startup log
+## The test Vertica server startup log
 
 ```shell
 docker logs verticasdk
 ```
 
-#### Stopping and removing the test Vertica server
+## Stopping and removing the test Vertica server
 
 When you are done using the container, you can stop it:
 
@@ -201,7 +203,7 @@ When you are done with the container, it is probably a good idea to also remove 
 docker volume rm verticasdk-data
 ```
 
-### Loading your UDx into the test Vertica server
+## Loading your UDx into the test Vertica server
 
 When the test Vertica server is ready, you can use `vsql` to load the UDx. The following command loads the `AggregateFunctions` library and execute some functions from it:
 
@@ -213,7 +215,7 @@ To view `AggregateFunctions.sql` and other example library SQL files, see `/opt/
 
 For additional details about working with UDx libraries, see [User-Defined Extensions](https://www.vertica.com/docs/latest/HTML/Content/Authoring/ExtendingVertica/UsingUserDefinedExtensions.htm).
 
-## Testing the container
+# Testing the container
 
 (This section describes testing the UDx container after you've modified the container (i.e., something in this repository).  For testing your UDx, see [Testing your UDx](#testing-your-udx).)
 
@@ -230,4 +232,4 @@ Run `make test` with the `TARGET` environment variable:
 ```shell
 $ make test TARGET=deb
 ```
-Note that the scripts need to know the tag for the container, which is derived from the VERTICA_VERSION environment variable.  If you have a canonically-named RPM or .deb, the makefile knows how to extract the VERTICA_VERSION from the filename, otherwise you will have to specify it, just as you did when you created the container.
+> **NOTE**: The scripts need to know the tag for the container, which is derived from the VERTICA_VERSION environment variable.  If you have a canonically-named RPM or .deb, the makefile knows how to extract the VERTICA_VERSION from the filename, otherwise you will have to specify it, just as you did when you created the container.

--- a/UDx-container/README.md
+++ b/UDx-container/README.md
@@ -165,16 +165,16 @@ In the previous diagram:
 
 ### Making your UDx accessible to the test Vertica server
 
-Start the server in your UDx working directory so when the container for the test Vertica server starts and it mounts its current working directory it has a path to your UDx working directory.  The Vertica in the container runs as dbadmin
+Start the server in your UDx working directory. This provides the container for the test Vertica server a path to your UDx working directory when it starts and it mounts its current working directory. The Vertica in the container runs as `dbadmin`.
 
 
 ### Starting the test Vertica server
 
-In addition to the "apps" `vsdk-make`, `vsdk-g++`, etc., there is a `vsdk-vertica` command which creates a scratch Vertica server for you to test your UDx.
+In addition to the tools such as `vsdk-make` and `vsdk-g++`, there is a `vsdk-vertica` command that creates a scratch Vertica server so you can test your UDx.
 
-The UDx container itself is not writable, so it creates and mounts a Docker volume called verticasdk-data.  It also mounts the current working directory and your home directory in the container (with the same name those directories have on the host machine).  In addition, `vsdk-vertica` understands the `VSDK_MOUNT` and `VSDK_ENV` environment variables described in [environment variable](#environment-variables).
+The UDx container itself is not writable, so it creates and mounts a Docker volume called `verticasdk-data`. It also mounts the current working directory and your home directory in the container using the same names those directories have on the host machine. In addition, `vsdk-vertica` understands the `VSDK_MOUNT` and `VSDK_ENV` environment variables described in [environment variable](#environment-variables).
 
-`vsdk-vertica` launches a server that runs in the background in a container named `verticasdk`.  You can read the container log using the command:
+`vsdk-vertica` launches a server that runs in the background in a container named `verticasdk`.  You can read the container log using the `docker logs` command.
 
 #### The test Vertica server startup log
 
@@ -231,4 +231,3 @@ Run `make test` with the `TARGET` environment variable:
 $ make test TARGET=deb
 ```
 Note that the scripts need to know the tag for the container, which is derived from the VERTICA_VERSION environment variable.  If you have a canonically-named RPM or .deb, the makefile knows how to extract the VERTICA_VERSION from the filename, otherwise you will have to specify it, just as you did when you created the container.
-

--- a/one-node-ce/README.md
+++ b/one-node-ce/README.md
@@ -13,38 +13,38 @@ This Dockerfile creates a single-node container using the [Vertica Community Edi
 ## Prerequisites
 Install [Docker Desktop](https://www.docker.com/get-started) or [Docker Engine](https://docs.docker.com/engine/install/).
 
-## Supported Platforms
+# Supported Platforms
 
 Container techology provides the freedom to run environments independently of the host operating system. For example, you can run a CentOS container on an Ubuntu workstation, and vice versa.
 
 Vertica provides a Dockerfile for different distributions so that you can create an containerized environment that you are the most comfortable with. This is helpful if you need to access a container shell to perform tasks, such as administering the database with [admintools](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/AdminTools/WritingAdministrationToolsScripts.htm).
 
-### Vertica:
+## Vertica:
 - 11.x
 - 10.x (beta)
 
-### CentOS
+## CentOS
 - 8.3
 - 7.9
 
-### Ubuntu
+## Ubuntu
 - 20.04
 - 18.04
 
 Vertica tests the CentOS containers most thoroughly.  Dockerfile_Ubuntu is provided for those who have a Vertica .deb file instead of a Vertica .rpm file, and can be adapted for recent versions of Debian.
 
-## Building the image
+# Building the image
 
-### Store the Vertica RPM or DEB
+## Store the Vertica RPM or DEB
 
 To build an image using this repository, you must store your Vertica RPM or DEB archive in the `./packages` directory.
 
 If you do not have a Vertica RPM, register to download the free [Community Edition](https://www.vertica.com/try/) license. This is a limited license that allows you to create a three-node Vertica cluster with a maximum of 1TB of storage.
 
-### Build the image with `Makefile`
+## Build the image with `Makefile`
 Vertica provides the `Makefile` script that creates an image with a [DBADMIN role](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PredefinedRoles.htm).
 
-The following variables can be exported to customize the image properties.
+Export the following variables to customize the image properties:
 
 | Environment Variable | Description | Default Values |
 | :--------------------| :-----------| :--------------|
@@ -54,13 +54,11 @@ The following variables can be exported to customize the image properties.
 | OS_VERSION   | Required OS versions.      | CentOS: 7.9.2009<br> Ubuntu: 18.04 | 
 | VERTICA_PACKAGE | Name of the .rpm or .deb file | CentOS: vertica-x86_64.RHEL6.latest.rpm<br>Ubuntu: vertica.latest.deb |
 
-The defaults may not be suitable for your site, you may want to edit the `Makefile` to use more appropriate defaults.
+> **NOTE**: The defaults might not be suitable for your site, you may want to edit the `Makefile` to use more appropriate defaults.
 
-If you don't specify a VERTICA_PACKAGE, and the TAG is not
-'latest' then the TAG is expected to be the vertica version and used
-to construct the VERTICA_PACKAGE name
+If you do not specify VERTICA_PACKAGE, and TAG is not 'latest', then the TAG must be the Vertica version because it is used to construct the version portion of the VERTICA_PACKAGE name.
 
-#### Examples:
+### Examples:
 ```shell
 # Builds image with default values.
 make 
@@ -75,7 +73,7 @@ make OS_TYPE=Ubuntu Tag=latest
 make VERTICA_PACKAGE=vertica-11.0.0.x86_64.RHEL6.rpm
 ```
 
-### Build Custom image
+## Build Custom image
 
 To customize build-time variables including the default database user, and group, and database name, export following optional variables:
 
@@ -86,7 +84,7 @@ To customize build-time variables including the default database user, and group
 | VERTICA_DB_GROUP  | Group for database administrator users.  | verticadba | 
 | VERTICA_DB_NAME   | Vertica database name.                   | VMart | 
 
-#### Example:
+### Example:
 ```shell
 make IMAGE_NAME=one-node-ce TAG=latest VERTICA_DB_USER=vertica VERTICA_DB_UID=1200
 ```
@@ -95,7 +93,7 @@ After `Dockerfile_<distro>` installs the RPM or DEB file, it runs `tools/cleanup
 
 # Testing with ./run_tests.sh
 
-Once you have built your container, you can test it using the `./run_tests.sh` script (or by running `make test`). The `./run_tests.sh` script verifies that the container can execute Vertica and some of the additional libraries. This script requires a [local copy of the vsql client](#getting-a-local-copy-of-vsql). 
+After you build the container, you can test it using the `./run_tests.sh` script (or by running `make test`). The `./run_tests.sh` script verifies that the container can execute Vertica and some of the additional libraries. This script requires a [local copy of the vsql client](#getting-a-local-copy-of-vsql). 
 
 The `./run_tests.sh` script uses the normal Vertica port number, so you must stop any existing Vertica server (container or otherwise) on your test system before you test your container.
 
@@ -103,7 +101,7 @@ The test uses your image to create a new container with a unique tag and volume.
 
 If the tests pass, `All tests passed` appears at the end of the output, and the script exits with a 0 exit status. If the test fails with errors, the output contains `ERROR: <description>`, where `<description>` is a description of the error.
 
-You can run the script with the `-k` argument to retain the container and make it available for examination:
+You can run the script with the `-k` argument to retain the container and make it available for examination after testing:
 
 ```shell
 ./run-test.sh -k
@@ -116,11 +114,11 @@ docker stop vertica_ce_<suffix>
 docker rm vertica_ce_<suffix>
 docker volume rm vertica-test-<suffix>
 ```
-In the previous command, `<suffix>` refers to the numeric suffix (the PID of the test-script shell that created the container and its volume). When used with the `-k` flag, `run-test.sh` prints out the above commands with `<suffix>` filled in.
+In the previous command, `<suffix>` refers to the numeric suffix (the PID of the test-script shell that created the container and its volume). When used with the `-k` flag, `run-test.sh` prints out the above commands and populates `<suffix>`.
 
-## How to use this image
+# How to use this image
 
-### Start the Vertica server instance
+## Start the Vertica server instance
 
 Vertica provides the `start-vertica.sh` script with the following options:
 
@@ -137,18 +135,18 @@ Options are:
  -V volume - docker volume to use for the Vertica database (default is vertica-data)
 ```
 
-**NOTE**: By default, the container name is `vertica_ce`. Use this name to identify the container in your local Docker registry, with commands like `docker start` and `docker stop`.
+> **NOTE**: By default, the container name is `vertica_ce`. Use this name to identify the container in your local Docker registry, with commands like `docker start` and `docker stop`.
 
-#### cid.txt file
+### cid.txt file
 
 The `start-vertica.sh` script creates the **cid.txt** file, which stores the container ID within the container. By default, **cid.txt** is stored in current working directory. You can specify a directory to place the **cid.txt** file using the `-d cid_dir` option. For example, the following command places **cid.txt** in the home directory:
 
 ```shell
 start-vertica.sh -d /home
 ```
-**NOTE**: You must have read and write access to the `cid_dir`.
+> **NOTE**: You must have read and write access to the `cid_dir`.
 
-### Start with `docker run`
+## Start with `docker run`
 
 You can also use `docker run`. In the following example, `vertica-ce:latest` is the container image you created in [Building the image](#building-the-image):
 
@@ -160,7 +158,7 @@ docker run -p 5433:5433 \
 ```
 
 
-### Custom scripts
+## Custom scripts
 
 The entrypoint script can run custom scripts during startup. You must store the scripts in a local directory named `.docker-entrypoint-initdb.d`. To make these scripts accessible by the entrypoint script, mount this directory in the container filesystem in `/docker-entrypoint-initdb.d/`. Scripts are executed in lexicographical order.
 
@@ -179,7 +177,7 @@ docker run -p 5433:5433 \
 
 For more information, see [Use bind mounts](https://docs.docker.com/storage/bind-mounts/) in the Docker documentation.
 
-### Container shell access
+## Container shell access
 
 If you used the `start-vertica.sh` script to [start the server instance](#start-the-vertica-server-instance), use the `run-shell-in-container.sh` script to access a shell within a container. This script uses the **cid.txt** file that the `start-vertica.sh` creates to store the container ID. In the following command, `<cid_dir>` is the directory that stores **cid.txt**:
 
@@ -191,7 +189,7 @@ You must specify either `-d directory-for-cid.txt` or `-n container-name` (e.g.,
 
 `-u uid` specifies what user runs inside the container. Vertica recommends that you use DBADMIN_ID (default 1000), because that user has proper access to Vertica directories inside the container.
 
-**NOTE**: If you have a [local copy](#getting-a-local-copy-of-vsql) of `vsql`, you do not need to access a container shell unless you need to use [admintools](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/AdminTools/WritingAdministrationToolsScripts.htm).
+> **NOTE**: If you have a [local copy](#getting-a-local-copy-of-vsql) of `vsql`, you do not need to access a container shell unless you need to use [admintools](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/AdminTools/WritingAdministrationToolsScripts.htm).
 
 Alternately, use the `docker exec` command to access a shell in the container. Using `docker exec` requires that you provide the container name:
 
@@ -207,11 +205,9 @@ You can access a container shell and vsql with a single command:
 docker exec -it <container_name> /opt/vertica/bin/vsql
 ```
 
-### Viewing container logs
+## Viewing container logs
 
-Retrieve the container logs with the `docker logs` command.
-
-The following command uses **cid.txt**:
+Retrieve the container logs with the `docker logs` command. The following command uses **cid.txt**:
 
 ```shell
 docker logs `cat cid.txt`
@@ -221,11 +217,9 @@ The following command fetches the logs for a container named **vertica_ce**:
 ```shell
 docker logs vertica_ce
 ```
-### Stopping the container
+## Stopping the container
 
-Stop the container with the `docker stop` command.
-
-The following command uses **cid.txt**:
+Stop the container with the `docker stop` command. The following command uses **cid.txt**:
 
 ```shell
 docker stop `cat cid.txt`
@@ -236,15 +230,15 @@ The following command stops a container named **vertica_ce**:
 docker logs vertica_ce
 ```
 
-## External database access
+# External database access
 
 The container exposes port 5433 for external client access. To access the database from outside the container, you must have a local copy of vsql.
 
-### Getting a local copy of vsql
+## Getting a local copy of vsql
 
 See [Client Drivers](https://www.vertica.com/download/vertica/client-drivers/) in Vertica Downloads to download all available client drivers.
 
-#### Accessing the database
+## Accessing the database
 
 By default, the Dockerfile creates the `dbadmin` user in the container database. The following command accesses the database:
 ```shell
@@ -261,13 +255,13 @@ This container mounts a Docker volume named **vertica-data** in the container as
 
 For details about managing volumes, see the [Docker documentation](https://docs.docker.com/storage/volumes/).
 
-**NOTE**: Docker volumes live on the host filesystem as directories. These directories are created automatically and stored at `/var/lib/docker/volumes/`. Each volume is stored under `./volumename/_data/`. This might limit the amount of data you can store in your database if that directory is on a small filesystem.
+> **NOTE**: Docker volumes live on the host filesystem as directories. These directories are created automatically and stored at `/var/lib/docker/volumes/`. Each volume is stored under `./volumename/_data/`. This might limit the amount of data you can store in your database if that directory is on a small filesystem.
 
-## Extend the image
+## Extending the image
 
 The `dbadmin` user environment is extended to be user-friendly. For details, see the [vertica_env.sh](env_setup/vertica_env.sh) and [.vsqlrc](env_setup/.vsqlrc) scripts.
 
-### Environment variables
+## Environment Variables
 
 To configure various aspects of Vertica in container runtime, inject corresponding environment variables when executing the `docker run` command:
 ```shell
@@ -281,9 +275,9 @@ The following table contains configurable environment variable parameters:
 | :--------------------| :-----------|
 | APP_DB_USER | Name of a database user, in addition to `vertica_db_user`. This user is created only when this variable is set. By default, this user is assigned [pseudosuperuser](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PSEUDOSUPERUSERRole.htm) privileges. |
 | APP_DB_PASSWORD | Password for APP_DB_USER. If this is omitted, the password is empty. |
-| TZ: "${VERTICA_CUSTOM_TZ:-Europe/Prague}" | The database time zone.<br>**IMPORTANT**: Vertica does not contain all timezones. Each Dockerfile contains a  commented-out workaround solution that begins "Link OS timezones". Uncomment the workaround to use time zones.<br>Setting the time zone with VERTICA_CUSTOM_TZ enables you to override it from your environment. |
-| DEBUG_FAILING_STARTUP | For development purposes. When you set the value to **y**, the entrypoint script does not end in case of failure, so you can investigate any failures. |
+| TZ: "${VERTICA_CUSTOM_TZ:-Europe/Prague}" | The database time zone.<br><br>**IMPORTANT**: Vertica does not contain all timezones. Each Dockerfile contains a  commented-out workaround solution that begins "Link OS timezones". Uncomment the workaround to use time zones.<br>Setting the time zone with VERTICA_CUSTOM_TZ enables you to override it from your environment. |
+| DEBUG_FAILING_STARTUP | For development purposes. When you set the value to `y`, the entrypoint script does not end in case of failure, so you can investigate any failures. |
 
-## References and Contributions
+# References and Contributions
 
 Thanks to [gooddata](https://github.com/gooddata/docker-image-for-vertica) for providing the implementation on which this work is based.

--- a/one-node-ce/README.md
+++ b/one-node-ce/README.md
@@ -95,15 +95,13 @@ After `Dockerfile_<distro>` installs the RPM or DEB file, it runs `tools/cleanup
 
 # Testing with ./run_tests.sh
 
-Once you have built your container, you can test it using the `./run_tests.sh` script (or by running `make test`).
+Once you have built your container, you can test it using the `./run_tests.sh` script (or by running `make test`). The `./run_tests.sh` script verifies that the container can execute Vertica and some of the additional libraries. This script requires a [local copy of the vsql client](#getting-a-local-copy-of-vsql). 
 
-The `./run_tests.sh` script verifies that the container can execute Vertica and some of the additional libraries. This script requires a [local copy of the vsql client](#getting-a-local-copy-of-vsql). 
+The `./run_tests.sh` script uses the normal Vertica port number, so you must stop any existing Vertica server (container or otherwise) on your test system before you test your container.
 
-Before you test your container, you must stop any existing Vertica server (container or otherwise) on your test system because the `./run_tests.sh` script uses the normal Vertica port number.
+The test uses your image to create a new container with a unique tag and volume. Because the test sets up the optional libraries and creates the VMart database, creating a new container can take up to three minutes.
 
-The test uses your image to create a new container with a unique tag, and volume. Because the test sets up the optional libraries and creates the VMart database, creating a new container can take as long as three minutes.
-
-If the tests pass, "All tests passed" appears at the end of the output, and the script exits with a 0 exit status. If the test fails with errors, the output contains `ERROR: <description>`, where `<description>` is a description of the error.
+If the tests pass, `All tests passed` appears at the end of the output, and the script exits with a 0 exit status. If the test fails with errors, the output contains `ERROR: <description>`, where `<description>` is a description of the error.
 
 You can run the script with the `-k` argument to retain the container and make it available for examination:
 
@@ -189,9 +187,9 @@ If you used the `start-vertica.sh` script to [start the server instance](#start-
 ./run-shell-in-container.sh [-d directory-for-cid.txt] [-n container-name] [-u uid] [-h ] [ ? ]
 ```
 
-One needs to specify either `-d directory-for-cid.txt` or `-n container-name` (e.g., `-n vertica_ce`).
+You must specify either `-d directory-for-cid.txt` or `-n container-name` (e.g., `-n vertica_ce`).
 
-`-u uid` specifies what user runs inside the container --- you probably want to use DBADMIN_ID (default 1000), since that user has proper access to Vertica directories inside the container.
+`-u uid` specifies what user runs inside the container. Vertica recommends that you use DBADMIN_ID (default 1000), because that user has proper access to Vertica directories inside the container.
 
 **NOTE**: If you have a [local copy](#getting-a-local-copy-of-vsql) of `vsql`, you do not need to access a container shell unless you need to use [admintools](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/AdminTools/WritingAdministrationToolsScripts.htm).
 
@@ -209,26 +207,30 @@ You can access a container shell and vsql with a single command:
 docker exec -it <container_name> /opt/vertica/bin/vsql
 ```
 
-### View container logs
+### Viewing container logs
 
-You can use **cid.txt** with the `docker logs` command:
+Retrieve the container logs with the `docker logs` command.
+
+The following command uses **cid.txt**:
 
 ```shell
 docker logs `cat cid.txt`
 ```
-... or use the container name to view the logs. For example, the following command fetches the logs for a container named **vertica_ce**:
+The following command fetches the logs for a container named **vertica_ce**:
 
 ```shell
-docker stop vertica_ce
+docker logs vertica_ce
 ```
-### Stop the container
+### Stopping the container
 
-You can use **cid.txt** with the `docker stop` command:
+Stop the container with the `docker stop` command.
+
+The following command uses **cid.txt**:
 
 ```shell
 docker stop `cat cid.txt`
 ```
-... or stop the container using the container name. For example, the following command stops a container named **vertica_ce**:
+The following command stops a container named **vertica_ce**:
 
 ```shell
 docker logs vertica_ce
@@ -277,9 +279,9 @@ The following table contains configurable environment variable parameters:
 
 | Environment Variable | Description | 
 | :--------------------| :-----------|
-| APP_DB_USER | Name of a database user, in addition to `vertica_db_user`. This user is created only when this variable is set. by default, this user receives [pseudosuperuser](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PSEUDOSUPERUSERRole.htm) privileges. |
+| APP_DB_USER | Name of a database user, in addition to `vertica_db_user`. This user is created only when this variable is set. By default, this user is assigned [pseudosuperuser](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PSEUDOSUPERUSERRole.htm) privileges. |
 | APP_DB_PASSWORD | Password for APP_DB_USER. If this is omitted, the password is empty. |
-| TZ: "${VERTICA_CUSTOM_TZ:-Europe/Prague}" | The database time zone.<br>**IMPORTANT**: Vertica does not contain all timezones. There is a commented-out workaround solution in each Dockerfile that begins "Link OS timezones". Uncomment the workaround to use time zones.<br>Setting the time zone with VERTICA_CUSTOM_TZ enables you to override it from your environment. |
+| TZ: "${VERTICA_CUSTOM_TZ:-Europe/Prague}" | The database time zone.<br>**IMPORTANT**: Vertica does not contain all timezones. Each Dockerfile contains a  commented-out workaround solution that begins "Link OS timezones". Uncomment the workaround to use time zones.<br>Setting the time zone with VERTICA_CUSTOM_TZ enables you to override it from your environment. |
 | DEBUG_FAILING_STARTUP | For development purposes. When you set the value to **y**, the entrypoint script does not end in case of failure, so you can investigate any failures. |
 
 ## References and Contributions

--- a/one-node-ce/README.md
+++ b/one-node-ce/README.md
@@ -42,7 +42,7 @@ To build an image using this repository, you must store your Vertica RPM or DEB 
 If you do not have a Vertica RPM, register to download the free [Community Edition](https://www.vertica.com/try/) license. This is a limited license that allows you to create a three-node Vertica cluster with a maximum of 1TB of storage.
 
 ## Build the image with `Makefile`
-Vertica provides the `Makefile` script that creates an image with a [DBADMIN role](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PredefinedRoles.htm).
+This repository contains the `Makefile` script that creates an image with a [DBADMIN role](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PredefinedRoles.htm).
 
 Export the following variables to customize the image properties:
 
@@ -54,9 +54,9 @@ Export the following variables to customize the image properties:
 | OS_VERSION   | Required OS versions.      | CentOS: 7.9.2009<br> Ubuntu: 18.04 | 
 | VERTICA_PACKAGE | Name of the .rpm or .deb file | CentOS: vertica-x86_64.RHEL6.latest.rpm<br>Ubuntu: vertica.latest.deb |
 
-> **NOTE**: The defaults might not be suitable for your site, you may want to edit the `Makefile` to use more appropriate defaults.
+> **NOTE**: If the defaults are not be suitable for your environment, edit the `Makefile` to use more appropriate defaults.
 
-If you do not specify VERTICA_PACKAGE, and TAG is not 'latest', then the TAG must be the Vertica version because it is used to construct the version portion of the VERTICA_PACKAGE name.
+If you do not specify VERTICA_PACKAGE, and TAG is not set to `latest`, then the TAG must be the Vertica version because it is used to construct the version portion of the VERTICA_PACKAGE name.
 
 ### Examples:
 ```shell
@@ -93,7 +93,9 @@ After `Dockerfile_<distro>` installs the RPM or DEB file, it runs `tools/cleanup
 
 # Testing with ./run_tests.sh
 
-After you build the container, you can test it using the `./run_tests.sh` script (or by running `make test`). The `./run_tests.sh` script verifies that the container can execute Vertica and some of the additional libraries. This script requires a [local copy of the vsql client](#getting-a-local-copy-of-vsql). 
+After you build the container, you can test it with `make test` or with the `./run_tests.sh` script. The `./run_tests.sh` script verifies that the container can execute Vertica and some of the additional libraries.
+
+> **IMPORTANT**: `./run_tests.sh` requires a [local copy of the vsql client](#getting-a-local-copy-of-vsql). 
 
 The `./run_tests.sh` script uses the normal Vertica port number, so you must stop any existing Vertica server (container or otherwise) on your test system before you test your container.
 
@@ -120,7 +122,7 @@ In the previous command, `<suffix>` refers to the numeric suffix (the PID of the
 
 ## Start the Vertica server instance
 
-Vertica provides the `start-vertica.sh` script with the following options:
+This repository contains the `start-vertica.sh` script with the following options:
 
 ```shell
 Usage: ./start-vertica.sh [-c cname] [-d cid_dir] [-h] [-i img_name] [-t tag] [-v hostpath:containerdir] -V docker-volume
@@ -148,7 +150,7 @@ start-vertica.sh -d /home
 
 ## Start with `docker run`
 
-You can also use `docker run`. In the following example, `vertica-ce:latest` is the container image you created in [Building the image](#building-the-image):
+You can also use `docker run` to start the server instance. In the following example, `vertica-ce:latest` is the container image you created in [Building the image](#building-the-image):
 
 ```shell
 docker run -p 5433:5433 \
@@ -185,7 +187,7 @@ If you used the `start-vertica.sh` script to [start the server instance](#start-
 ./run-shell-in-container.sh [-d directory-for-cid.txt] [-n container-name] [-u uid] [-h ] [ ? ]
 ```
 
-You must specify either `-d directory-for-cid.txt` or `-n container-name` (e.g., `-n vertica_ce`).
+You must specify either `-d directory-for-cid.txt` or `-n container-name`. For example, `-n vertica_ce`.
 
 `-u uid` specifies what user runs inside the container. Vertica recommends that you use DBADMIN_ID (default 1000), because that user has proper access to Vertica directories inside the container.
 
@@ -207,7 +209,7 @@ docker exec -it <container_name> /opt/vertica/bin/vsql
 
 ## Viewing container logs
 
-Retrieve the container logs with the `docker logs` command. The following command uses **cid.txt**:
+Fetch the container logs with the `docker logs` command. The following command uses **cid.txt**:
 
 ```shell
 docker logs `cat cid.txt`
@@ -232,7 +234,7 @@ docker logs vertica_ce
 
 # External database access
 
-The container exposes port 5433 for external client access. To access the database from outside the container, you must have a local copy of vsql.
+The container exposes port 5433 for external client access. To access the database from outside the container, you must have a [local copy of the vsql client](#getting-a-local-copy-of-vsql).
 
 ## Getting a local copy of vsql
 

--- a/one-node-ce/dockerhub.md
+++ b/one-node-ce/dockerhub.md
@@ -4,13 +4,14 @@
 This is a single-node Docker [Community Edition](https://www.vertica.com/docs/latest/HTML/Content/Authoring/GettingStartedGuide/DownloadingAndStartingVM/DownloadingAndStartingVM.htm) image for Vertica. The base OS for the image is CentOS7.9.2009 with a Vertica Version 11.0.1 CE.
 
 # Supported Tags
-* 11.0.1-0, latest
+* 11.1.0-0, latest
+* 11.0.1-0
 * 11.0.0-0
 * 10.1.1-0
 
 # Quick Reference
 
-* [Official Vertica Documentation](https://www.vertica.com/docs/latest/HTML/Content/Home.htm)
+* [Vertica Documentation](https://www.vertica.com/docs/latest/HTML/Content/Home.htm)
 * Supported architectures: `amd64`
 
 # What is Vertica?
@@ -62,9 +63,12 @@ docker exec -it <container_name> /opt/vertica/bin/vsql
 
 ## Access the database via vsql/client:
 
-The `5433` and`5444` port will be mapped to your host, which means you need to leave this port unoccupied.
+The `5433` and`5444` ports will be mapped to your host, which means you need to leave these ports unoccupied.
 
-You can then access the database, either via vsql on the container, vsql on the host, or via an external client using the `5433` and`5444` port.
+You can then access the database in one of the following ways:
+- vsql on the container
+- vsql on the host
+- An external client using the `5433` and`5444` port
 
 ## Persisting data:
 This container mounts a Docker volume named `vertica-data` in the container as a persistent data store for the Vertica database. A Docker volume is used instead of a mounted host directory for the following reasons:
@@ -74,18 +78,18 @@ This container mounts a Docker volume named `vertica-data` in the container as a
 
 > **Note**: Docker volumes live on the host filesystem as directories. These directories are created automatically and stored at `/var/lib/docker/volumes/`. Each volume is stored under `./volumename/_data/`. This might limit the amount of data you can store in your database if that directory is on a small filesystem.
 
-You may also use a bind mount to another directory that is mounted on a sufficient disk, if you dont want to use docker volumes:
+You might also use a bind mount to another directory that is mounted on a sufficient disk, if you dont want to use docker volumes:
 ```sh
 docker run -p 5433:5433 -p 5444:5444\
            --mount type=bind,source=/<directory>,target=/data \
            --name vertica_ce \
            vertica/vertica-ce
 ```
-Make sure the user running `docker run` has enough privileges to read and write the source directory.
+Make sure the user running `docker run` has read and write privileges on the source directory.
 
 ## Use with Docker Compose:
 
-You may use the Docker image in with docker-compose. Following is an example:
+You can use the Docker image in with docker-compose. The following is an example YAML file:
 ```yaml
 version: "3.9"
 services:
@@ -114,7 +118,7 @@ Run `docker-compose up`:
 docker-compose --file ./docker-compose.yml --project-directory <directory_name> up -d
 ```
 
-> Note: We are yet to test integration of this with other services. So, we do not have more information on network setup.
+> **Note**: We have not tested this integration, so we do not have network setup recommendations.
 
 
 ## License:


### PR DESCRIPTION
Updated and made copy edits on all READMEs and one-node CE dockerhub.md file. Notable changes include the following:
- Removed one heading level. h4s (####) should be used rarely. This should make the sections a bit more clear
- Put NOTE: and IMPORTANT: in block quotes
- Reorganized the top-level page
- general copy edits