### PR TITLE
Allow the RPM to be in a different directory

### DIFF
--- a/UDx-container/Makefile
+++ b/UDx-container/Makefile
@@ -16,7 +16,10 @@ VERTICA_RPM ?= vertica.rpm
 docker-image: .dockerimage
 
 .dockerimage: $(VERTICA_RPM) Makefile Dockerfile
+        # link/copy rpm file to local directory and clean it up when done
+	ln $(VERTICA_RPM) vertica.$$$$.rpm || cp $(VERTICA_RPM) vertica.$$$$.rpm ; \
+	trap "rm -f vertica.$$$$.rpm" EXIT INT; \
 	docker build \
-		--build-arg RPM=$(VERTICA_RPM) \
+		--build-arg RPM=vertica.$$$$.rpm \
 		--tag $(CONTAINER_TAG) .
 	touch .dockerimage


### PR DESCRIPTION
Docker requires the install files to be in the current working
directory.  This change will create a hardlink to the RPM file , but if
the RPM is on a different device, it falls back to copying the rpm to
the current working directory.  Then, after docker is done with it, the
newly created link/copy is deleted.  Interrupting the process should
still remove the file if it can.