### PR TITLE
Doc updates: Repo and scheduler README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ The UDx-container directory packages in a container the following resources requ
 
 ## [Kafka Scheduler](vertica-kafka-scheduler)
 
-The [kafka-scheduler](https://hub.docker.com/repository/docker/vertica/kafka-scheduler) container runs the [Kafka Scheduler](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/AutomaticallyCopyingDataFromKafka.htm), a standalone Java application that automatically consumes data from one or more Kafka topics and loads structured data into Vertica.
+The kafka-scheduler directory provides tools to maintain a the official [vertica/kafka-scheduler](https://hub.docker.com/r/vertica/kafka-scheduler) container, or build a custom containerized version of the [Vertica Kafka Scheduler](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/AutomaticallyCopyingDataFromKafka.htm), a standalone Java application that automatically consumes data from one or more Kafka topics and then loads the structured data into Vertica.
 
-
-The Kafka Scheduler provides the following advantages over manual data loads with COPY:
-- The streamed data automatically appears in your database according to the [frame duration](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/ChoosingFrameDuration.htm).
+The Kafka Scheduler provides the following advantages over manually loading data with COPY statements:
+- Streamed data automatically loads in your database according to the [frame duration](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/ChoosingFrameDuration.htm).
 - The Kafka Scheduler manages offsets to ensure an exactly-once message consumption process from Kafka topics.
 - You can configure backup schedulers to provide high-availability. If the primary scheduler fails, the backup scheduler begins loading Kafka data where the failed scheduler left off.

--- a/README.md
+++ b/README.md
@@ -26,17 +26,10 @@ The UDx-container directory packages in a container the following resources requ
 
 ## [Kafka Scheduler](vertica-kafka-scheduler)
 
-This is a container for [the Vertica Kafka Scheduler](https://hub.docker.com/repository/docker/vertica/kafka-scheduler)
-on Docker Hub.  The Kafka Scheduler is a standalone java app that automatically
-consumes data from one or more Kafka topics, and loads structured data into
-Vertica.  Automatically loading streaming data has a number of advantages over
-manually using COPY:
+The [kafka-scheduler](https://hub.docker.com/repository/docker/vertica/kafka-scheduler) container runs the [Kafka Scheduler](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/AutomaticallyCopyingDataFromKafka.htm), a standalone Java application that automatically consumes data from one or more Kafka topics and loads structured data into Vertica.
 
-* The streamed data automatically appears in your database. The frequency with
-which new data appears in your database is governed by the scheduler's frame
-duration.
-* The scheduler provides an exactly-once consumption process. The schedulers
-manage offsets for you so that each message sent by Kafka is consumed once.
-* You can configure backup schedulers to provide high-availability. Should the
-primary scheduler fail for some reason, the backup scheduler automatically
-takes over loading data.
+
+The Kafka Scheduler provides the following advantages over manual data loads with COPY:
+- The streamed data automatically appears in your database according to the [frame duration](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/ChoosingFrameDuration.htm).
+- The Kafka Scheduler manages offsets to ensure an exactly-once message consumption process from Kafka topics.
+- You can configure backup schedulers to provide high-availability. If the primary scheduler fails, the backup scheduler begins loading Kafka data where the failed scheduler left off.

--- a/vertica-kafka-scheduler/README.md
+++ b/vertica-kafka-scheduler/README.md
@@ -1,9 +1,8 @@
 # Vertica-Kafka Scheduler
 
-
 This repository provides the tools to build and maintain a containerized version of the [Vertica Kafka Scheduler](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/AutomaticallyCopyingDataFromKafka.htm), a standalone Java application that automatically consumes data from one or more Kafka topics and then loads the structured data into Vertica. The scheduler is controlled by the `vkconfig` command line script.
 
-You can download the official [vertica/kafka-scheduler](https://hub.docker.com/r/vertica/kafka-scheduler) image, or you can use the Dockerfile in this repo to build a custom image. The official image is based on [alpine:3.14](https://hub.docker.com/_/alpine) and includes the [openjdk8-jre](https://hub.docker.com/_/openjdk).
+You can download the pre-built [vertica/kafka-scheduler](https://hub.docker.com/r/vertica/kafka-scheduler) image, or you can use the Dockerfile in this repo to build the image locally. The pre-built image is based on [alpine:3.14](https://hub.docker.com/_/alpine) and includes the [openjdk8-jre](https://hub.docker.com/_/openjdk).
 
 
 For in-depth details about streaming data with Vertica and Apache Kafka, see [Apache Kafka Integration](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/KafkaIntegrationGuide.htm) in the Vertica documentation.
@@ -166,7 +165,7 @@ Each component and the running scheduler process require access to the same data
 The components and running scheduler process access configuration file values from within the scheduler container filesystem, so you must mount the configuration file as a [volume](https://docs.docker.com/storage/volumes/). The scheduler expects the configuration file to be named `vkconfig.conf` and stored in the `/etc` directory. For example: 
 
 ```bash
-$ docker run -v <local-config.conf>:/etc/vkconfig.conf vertica/kafka-scheduler <options> ...
+$ docker run -v <local-config.conf>:/etc/vkconfig.conf vertica/kafka-scheduler vkconfig <component> --conf /etc/vkconfig.conf <options>
 ```
 
 For a sample configuration file, see [example.conf](example.conf) in this repository.
@@ -249,9 +248,9 @@ vkconfig microbatch --add \
 After you [create a scheduler](#create-a-scheduler), launch the scheduler to begin scheduling microbatches. To launch a scheduler, execute a `docker run` command that does the following:
 - Mounts a configuration file as a volume.
 - Specifies the scheduler image name.
-- Mounts the local `vkafka-log-config-debug.xml` file in the container's `/opt/vertica/packages/kafka/config` directory. This file configures log messages to help troubleshoot scheduler issues.
-- Mounts the local `/log` directory in the container's `/opt/vertica/log` directory to write logs to help troubleshoot scheduler issues.
-- Passes the Docker `--user` command to specify the user.
+- Mounts `vkafka-log-config-debug.xml` from the current directory file in the container's `/opt/vertica/packages/kafka/config` directory. This file configures log messages to help troubleshoot scheduler issues.
+- Mounts `/log` from the current directory into the container's `/opt/vertica/log` directory so that log messages are written to the local `/log` directory.
+- Passes the Docker `--user` command to specify the UID that has write access on the `/log` directory.
 
 The following command provides an example format. Execute this command from the top-level directory of your cloned repository:
 
@@ -284,7 +283,7 @@ Use the `build` target to create a custom container. Depending on your Vertica e
 | Variable        | Description |
 |:----------------|:------------|
 | VERTICA_INSTALL | The location of your Vertica binary installation. Define this variable if you want to copy the local install of the Java libraries.<br>**Default**: `/opt/vertica` |
-| VERTICA_VERSION | The Vertica version that you want to use to build the scheduler container. The scheduler version must match the Vertica database version. <br>**Default**: `latest` |
+| VERTICA_VERSION | The Vertica version that you want to use to build the scheduler container. The scheduler version must match the Vertica database version. <br>**Default**: The version of the Vertica binary that VERTICA_INSTALL points to. |
 
 For example, if you installed Vertica in a custom directory, use the following command:
 

--- a/vertica-kafka-scheduler/README.md
+++ b/vertica-kafka-scheduler/README.md
@@ -87,7 +87,7 @@ $ docker run \
         "
 ```
 
-For a complete example, see the **Set up Scheduler** section in the [example.sh](example.sh) script in this repository. The following snippet defines the first microbatch component in the script command:
+For a complete example, see the **Set up Scheduler** section in the [example.sh](example.sh) script in this repository. The following snippet from that section defines the first `microbatch` component:
 
 ```bash
 $ docker run \

--- a/vertica-kafka-scheduler/README.md
+++ b/vertica-kafka-scheduler/README.md
@@ -110,9 +110,9 @@ docker run -it \
         vkconfig launch --conf /etc/vkconfig.conf &
 ```
 The preceding command mounts the following files and directories in the scheduler container filesystem:
-- Local `vkconfig.conf` file in the container's `/etc` directory
-- Local `vkafka-log-config-debug.xml` file in the container's `/opt/vertica/packages/kafka/config` directory. This file structures log messages to help troubleshoot scheduler issues.
-- Local `/log` directory in the container's `/opt/vertica/log` directory to store logs to troubleshoot scheduler issues.
+- Local `vkconfig.conf` configuration file in the container's `/etc` directory
+- Local `vkafka-log-config-debug.xml` file in the container's `/opt/vertica/packages/kafka/config` directory. This file configures log messages to help troubleshoot scheduler issues.
+- Local `/log` directory in the container's `/opt/vertica/log` directory to write logs to help troubleshoot scheduler issues.
 
 Additionally, the command defines the following:
 - Passes the Docker `--user` command to define user that executes this `docker run` command as the default user within the scheduler container.
@@ -132,7 +132,6 @@ $ make build VERTICA_INSTALL=/path/to/vertica
 |:----------------|:------------|
 | VERTICA_INSTALL | The location of your Vertica binary installation. Define this variable if you want to copy the local install of the Java libraries.<br>**Default**: `/opt/vertica`. |
 | VERTICA_VERSION | The Vertica version that you want to use to build the vkconfig container.<br>**Default**: `latest`.|
-| VERSION | ?????????? |
 
 # Repository contents overview
 
@@ -189,31 +188,6 @@ A bash script that configures and runs a scheduler with test data, and logs the 
 This github repo builds a Vertica-Kafka scheduler docker container for the
 purposes of streaming data from Kafka to Vertica.  It requires Docker or some
 compatible container environment.
-
-## Quickstart
-
-```
-# Commands to configure a scheduler
-docker run vertica/kafka-scheduler vkconfig scheduler --help
-docker run vertica/kafka-scheduler vkconfig cluster --help
-docker run vertica/kafka-scheduler vkconfig source --help
-docker run vertica/kafka-scheduler vkconfig target --help
-docker run vertica/kafka-scheduler vkconfig load-spec --help
-docker run vertica/kafka-scheduler vkconfig microbatch --help
-docker run vertica/kafka-scheduler vkconfig statistics --help
-
-# Launching the scheduler with some useful docker options
-# use "-v" to map the optional conf file to the container's /etc/vconfig.conf
-# use "-v" to map the log config file to the container's /opt/vertica/packages/kafka/config/vkafka-log-config.xml
-# use "-v" to map the writable log directory to the internal /opt/vertica/log
-# use "--user" to run with the credentials of the log directory
-docker run -it \
-    -v $PWD/vkconfig.conf:/etc/vkconfig.conf vertica/kafka-scheduler \
-    -v $PWD/vkafka-log-config-debug.xml:/opt/vertica/packages/kafka/config/vkafka-log-config.xml \
-    -v $PWD/log:/opt/vertica/log \
-    --user $(perl -E '@s=stat "'"$PWD/log"'"; say "$s[4]:$s[5]"') \
-        vkconfig launch --conf /etc/vkconfig.conf
-```
 
 ## Example
 `example.sh` is a full example of configuring and running a scheduler.  It uses

--- a/vertica-kafka-scheduler/README.md
+++ b/vertica-kafka-scheduler/README.md
@@ -6,6 +6,8 @@ This repository provides the tools to build and maintain a containerized version
 You can download the official [vertica/kafka-scheduler](https://hub.docker.com/r/vertica/kafka-scheduler) image, or you can use the Dockerfile in this repo to build a custom image. The official image is based on [alpine:3.14](https://hub.docker.com/_/alpine) and includes the [openjdk8-jre](https://hub.docker.com/_/openjdk).
 
 
+For in-depth details about streaming data with Vertica and Apache Kafka, see [Apache Kafka Integration](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/KafkaIntegrationGuide.htm) in the Vertica documentation.
+
 ## Table of Contents
 
   - [Prerequisites](#prerequisites)
@@ -15,8 +17,7 @@ You can download the official [vertica/kafka-scheduler](https://hub.docker.com/r
       - [Configuration file](#configuration-file)
       - [Scheduler components](#scheduler-components)
       - [Create a scheduler](#create-a-scheduler)
-    - [Launching a scheduler](#launching-a-scheduler)
-    - [Building a custom scheduler container](#building-a-custom-scheduler-container)
+    - [Launching a scheduler](#launch-a-scheduler) - [Building a custom scheduler container](#building-a-custom-scheduler-container)
       - [Prerequisites](#prerequisites-1)
       - [`build` make target](#build-make-target)
     - [Push to Docker Hub](#push-to-docker-hub)
@@ -46,7 +47,7 @@ $ cd vertica-kafka-scheduler
 
 ### Configure a scheduler 
 
-A scheduler is composed of [individual components](#scheduler-components) that define the load frequency, data type, and Vertica and Kafka environments. After you define properties for each component, [launch the scheduler](#launching-the-scheduler) with configuration and logging utilities mounted as volumes.
+A scheduler is composed of [individual components](#scheduler-components) that define the load frequency, data type, and Vertica and Kafka environments. After you define properties for each component, [launch the scheduler](#launch-a-scheduler) with configuration and logging utilities mounted as volumes.
 
 #### Configuration file
 
@@ -137,7 +138,7 @@ vkconfig microbatch --add \
 ...
 ```
 
-### Launching a scheduler
+### Launch a scheduler
 
 After you [create a scheduler](#create-a-scheduler), launch the scheduler to begin scheduling microbatches. To launch a scheduler, execute a `docker run` command that does the following:
 - Mounts a configuration file as a volume.
@@ -168,7 +169,7 @@ In some circumstances, you might want to build a custom vertica/kafka-scheduler 
 - Vertica binary or rpm2cpio vertica.rpm | cpio -idmv and export VERTICA_INSTALL=./opt/vertica
 - Java libraries located in `/vertica/java`.
 
-For additional information about Vertica and Java development, see [Java SDK](https://www.vertica.com/docs/latest/HTML/Content/Authoring/ExtendingVertica/Java/DevelopingInJava.htm).
+For additional information about Vertica and Java development, see [Java SDK](https://www.vertica.com/docs/latest/HTML/Content/Authoring/ExtendingVertica/Java/DevelopingInJava.htm) in the Vertica documentation.
 
 #### `build` make target
 

--- a/vertica-kafka-scheduler/README.md
+++ b/vertica-kafka-scheduler/README.md
@@ -1,3 +1,113 @@
+There are two use cases for the github project – building the scheduler and running a demo.  Customers don’t need to build the scheduler unless they want to make their own private tweaks (like embedding their own config files in it, but that’s probably overengineering).  However, they may want to run the demo which can be done with “make test”.
+
+# Vertica-Kafka Scheduler
+
+This repository creates a containerized version of the Vertica Kafka Scheduler, a standalone Java application that automatically consumes data from one or more Kafka topics and loads structured data into Vertica.
+
+The Docker image is based on [alpine:3.14](https://hub.docker.com/_/alpine) and includes the [openjdk8-jre](https://hub.docker.com/_/openjdk).
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/get-started/), [Docker Engine](https://docs.docker.com/engine/install/), or another container runtime
+- [Vertica installation](https://www.vertica.com/docs/latest/HTML/Content/Authoring/InstallationGuide/Other/InstallingManually.htm)
+- Docker Compose
+
+
+## Supported Platforms
+
+
+
+## Repository overview
+
+This repository contains the following artifacts to help [test](#testing-the-container) and [build](#building-the-vertica-kafka-container) a vkconfig container
+
+### Makefile
+
+The Makefile contains the following targets:
+- `make help`: Displays the help for the Makefile.
+- `make version`: Displays the Vertica version that will be used in the build process.
+- `make java`: Copy the local install of the Java libraries from `/opt/vertica/java`.
+- `make kafka`: Copy the local install of the Kafka Scheduler from `/opt/vertica/packages/kafka`.
+- `make build`: Builds the container image.
+- `make push`: Pushes the custom container image to the remote Docker Hub repository.
+- `make test`: Runs [example.sh](#examplesh) to validate the vkconfig configuration.
+
+### docker-compose.yaml
+
+A [Compose file](https://docs.docker.com/compose/compose-file/) that starts the following services, each as a container:
+- [Zookeeper](https://hub.docker.com/r/bitnami/zookeeper)
+- [Kafka broker](https://hub.docker.com/r/bitnami/kafka/)
+- [Vertica](https://hub.docker.com/r/vertica/vertica-k8s)
+
+The Compose file creates the `scheduler` network so that the containers can communicate with each other.
+
+### example.conf
+
+A sample [configuration file](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/SettingUpAScheduler.htm#1). You can customize this file by replacing the default values or adding more [vkconfig script options](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/UtilityOptions/SharedUtilityOptions.htm).
+
+### example.sh
+
+A bash script that configures and runs a scheduler with test data, and logs the entire process to the console. The process involves the following steps: 
+1. Sets up a test environment using the [docker-compose.yaml](#docker-composeyaml) file. The environment includes the following:
+   - A Vertica database
+   - Required database packages
+   - Database table
+   - Database user
+   - Resource pool
+   - Two Kafka topics
+2. Creates a scheduler container with the [vertica/kafka-scheduler](https://hub.docker.com/r/vertica/kafka-scheduler) image, then creates the following components:
+   - Target Flex table 
+   - Parser
+   - Kafka source 
+   - Two Kafka topics 
+   - Two microbatches (one for each Kafka topic)
+3. Runs the scheduler.
+4. Sends JSON-formatted test data to Kafka.
+5. Displays the test data in the Flex table.
+6. Gracefully shuts down the scheduler.
+7. Removes the images pulled with the Compose file.
+
+
+
+## Testing the container
+
+If you build a 
+
+
+## Building the vertica-kafka container
+
+This repository provides a Makefile to build the vertica-kafka-scheduler with build conditions.
+
+When you build the container, the build process requires access to the Java libraries for your Vertica installation. By default, the Makefile assumes that you installed Vertica in the `/opt` directory. If you installed Vertica in a different directory, set the `VERTICA_INSTALL` configuration option when you build the container:
+
+```bash
+$ make build VERTICA_INSTALL=/path/to/vertica
+```
+
+### Build variables
+
+| Variable        | Description |
+|:----------------|:------------|
+| VERTICA_INSTALL | The location of your Vertica binary installation. Define this variable if you want to copy the local install of the Java libraries.<br>**Default**: `/opt/vertica`. |
+| VERTICA_VERSION | The Vertica version that you want to use to build the vkconfig container.<br>**Default**: `latest`.|
+| VERSION | ?????????? |
+
+## Environment setup
+
+### Configuration file 
+
+### Log configuration file 
+
+### Writable log directory 
+
+
+
+## Quickstart
+
+
+
+
+
 # Vertica-Kafka Scheduler
 
 This github repo builds a Vertica-Kafka scheduler docker container for the
@@ -13,7 +123,7 @@ docker run vertica/kafka-scheduler vkconfig cluster --help
 docker run vertica/kafka-scheduler vkconfig source --help
 docker run vertica/kafka-scheduler vkconfig target --help
 docker run vertica/kafka-scheduler vkconfig load-spec --help
-docker run vertica/kafka-scheduler vkconfig microbatch--help
+docker run vertica/kafka-scheduler vkconfig microbatch --help
 docker run vertica/kafka-scheduler vkconfig statistics --help
 
 # Launching the scheduler with some useful docker options

--- a/vertica-kafka-scheduler/README.md
+++ b/vertica-kafka-scheduler/README.md
@@ -2,7 +2,7 @@
 
 This repository provides the tools to build and maintain a containerized version of the [Vertica Kafka Scheduler](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/AutomaticallyCopyingDataFromKafka.htm), a standalone Java application that automatically consumes data from one or more Kafka topics and then loads the structured data into Vertica. The scheduler is controlled by the `vkconfig` command line script.
 
-You can download the pre-built [vertica/kafka-scheduler](https://hub.docker.com/r/vertica/kafka-scheduler) image, or you can use the Dockerfile in this repo to build the image locally. The pre-built image is based on [alpine:3.14](https://hub.docker.com/_/alpine) and includes the [openjdk8-jre](https://hub.docker.com/_/openjdk).
+You can download the pre-built [vertica/kafka-scheduler](https://hub.docker.com/r/vertica/kafka-scheduler) image, or you can use the Dockerfile in this repo to build the image locally. The image is based on [alpine:3.14](https://hub.docker.com/_/alpine) and includes the [openjdk8-jre](https://hub.docker.com/_/openjdk).
 
 
 For in-depth details about streaming data with Vertica and Apache Kafka, see [Apache Kafka Integration](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/KafkaIntegrationGuide.htm) in the Vertica documentation.
@@ -248,8 +248,8 @@ vkconfig microbatch --add \
 After you [create a scheduler](#create-a-scheduler), launch the scheduler to begin scheduling microbatches. To launch a scheduler, execute a `docker run` command that does the following:
 - Mounts a configuration file as a volume.
 - Specifies the scheduler image name.
-- Mounts `vkafka-log-config-debug.xml` from the current directory file in the container's `/opt/vertica/packages/kafka/config` directory. This file configures log messages to help troubleshoot scheduler issues.
-- Mounts `/log` from the current directory into the container's `/opt/vertica/log` directory so that log messages are written to the local `/log` directory.
+- Mounts the `vkafka-log-config-debug.xml` file in the current directory into the container's `/opt/vertica/packages/kafka/config` directory. This file configures log messages to help troubleshoot scheduler issues.
+- Mounts `log` in the current directory into the container as the `/opt/vertica/log` directory. This writes log messages to the local `log` directory.
 - Passes the Docker `--user` command to specify the UID that has write access on the `/log` directory.
 
 The following command provides an example format. Execute this command from the top-level directory of your cloned repository:

--- a/vertica-kafka-scheduler/README.md
+++ b/vertica-kafka-scheduler/README.md
@@ -1,23 +1,140 @@
-There are two use cases for the github project – building the scheduler and running a demo.  Customers don’t need to build the scheduler unless they want to make their own private tweaks (like embedding their own config files in it, but that’s probably overengineering).  However, they may want to run the demo which can be done with “make test”.
 
 # Vertica-Kafka Scheduler
 
-This repository creates a containerized version of the Vertica Kafka Scheduler, a standalone Java application that automatically consumes data from one or more Kafka topics and loads structured data into Vertica.
+This repository provides the tools to maintain and test a containerized version of the [Vertica Kafka Scheduler](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/AutomaticallyCopyingDataFromKafka.htm), a standalone Java application that automatically consumes data from one or more Kafka topics, and then loads it as structured data into Vertica. The scheduler is controlled by the `vkconfig` command line script.
 
-The Docker image is based on [alpine:3.14](https://hub.docker.com/_/alpine) and includes the [openjdk8-jre](https://hub.docker.com/_/openjdk).
+You can use the official [vertica/kafka-scheduler](https://hub.docker.com/r/vertica/kafka-scheduler) image, or you can use the Dockerfile in this repo to build a custom vkconfig image. The Docker image is based on [alpine:3.14](https://hub.docker.com/_/alpine) and includes the [openjdk8-jre](https://hub.docker.com/_/openjdk).
 
 ## Prerequisites
 
 - [Docker Desktop](https://www.docker.com/get-started/), [Docker Engine](https://docs.docker.com/engine/install/), or another container runtime
-- [Vertica installation](https://www.vertica.com/docs/latest/HTML/Content/Authoring/InstallationGuide/Other/InstallingManually.htm)
-- Docker Compose
+- [Vertica installation](https://www.vertica.com/docs/latest/HTML/Content/Authoring/InstallationGuide/Other/InstallingManually.htm) or [Vertica server image](https://hub.docker.com/r/vertica/vertica-k8s)
+- [vertica/kafka-scheduler](https://hub.docker.com/r/vertica/kafka-scheduler) image
+- (Optional) [Docker Compose](https://docs.docker.com/compose/install/) to run `example.sh`
+
+## Setting up a scheduler 
+
+A scheduler is composed of individual components that define the load frequency, data type, and Vertica and Kafka configurations. After you create the scheduler, run the vertica/kafka-scheduler container with `vkconfig` to launch the scheduler with local files and directories mounted as volumes.
+
+### Configuration file
+
+The configuration file provides the scheduler the following options that persist regardless of the other scheduler components:
+- `username`
+- `dbhost`
+- `dbport`
+- `config-schema`
+
+To provide the scheduler process access to these configuration values, you must mount the configuration file as a [volume](https://docs.docker.com/storage/volumes/) named vkconfig.conf in the /etc vertica/kafka-scheduler container filesystem. For example:
+
+```bash
+docker run -v <local-config.conf>:/etc/vkconfig.conf <options> ...
+```
+
+For an example configuration file, see [example.conf](example.conf) in this repository.
 
 
-## Supported Platforms
 
+### Scheduler components
 
+To set up a scheduler, use a single `docker run` command in the following format to mount the configuration file, select the scheduler image and version, and define the scheduler components:
 
-## Repository overview
+```bash
+$ docker run -v <local-config.conf>:/etc/vkconfig.conf <image-name>:<version> bash -c "<scheduler-configuration>"
+```
+
+In the preceding command, `<scheduler-configuration>` is a string that defines options on the following scheduler components:
+- `scheduler`: The scheduler itself
+- `target`: The Vertica table that receives the streaming data
+- `load-spec`: Defines the parser for the streaming data
+- `cluster`: Details about the Kafka server
+- `source`: A Kafka topic that sends data to Vertica
+- `microbatch`: Combines each of the preceding components into a single COPY statement that the Scheduler executes to load data into Vertica
+
+This repository contains the [example.sh](example.sh) script. The **Set up Scheduler** section in this script contains a complete example of how to pass a string of scheduler components and their configuration options to the `docker run` command. Each component uses the following format:
+
+```bash 
+vkconfig <component> --add \
+--conf /etc/vkconfig.conf \
+--<option> <value> [\ 
+... ]
+```
+
+> **NOTE**
+> You must pass the `--conf /etc/vkconfig.conf` option to each component in the scheduler.
+
+For example, the following snippet defines the first microbatch component, which combines previously defined components into one COPY statement definition:
+
+```bash
+$ docker run \
+...
+vkconfig microbatch --add \  
+  --conf /etc/vkconfig.conf \
+  --microbatch KafkaBatch1 \ 
+  --add-source KafkaTopic1 \ 
+  --add-source-cluster KafkaCluster \
+  --target-schema public \   
+  --target-table KafkaFlex \ 
+  --rejection-schema public \
+  --rejection-table KafkaFlex_rej \
+  --load-spec KafkaSpec; \
+...
+```
+
+For a list of all available options for each component, navigate to the top-level directory in this repository and run the following command:
+
+```bash
+docker run vertica/kafka-scheduler vkconfig <component> --help
+```
+
+For example, to view the description of each component in the preceding `vkconfig microbatch --add \ ...` command, enter the following: 
+
+```bash
+docker run vertica/kafka-scheduler vkconfig microbatch --help
+```
+
+> **NOTE**
+> Additionally, this container includes the `statistics` component that queries the [stream_microbatch_history table](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/KafkaTables/stream_microbatch_history.htm) for runtime statistics.
+
+## Launching the scheduler
+
+After you define a scheduler and the required components, use the `vkconfig launch` command to instruct the scheduler to start scheduling microbatches.
+
+When you execute the following `docker run` command from the top-level directory of this repository, it executes the `vkconfig launch` command to start the scheduler as a background process:
+
+```bash
+docker run -it \
+    -v $PWD/vkconfig.conf:/etc/vkconfig.conf vertica/kafka-scheduler \
+    -v $PWD/vkafka-log-config-debug.xml:/opt/vertica/packages/kafka/config/vkafka-log-config.xml \
+    -v $PWD/log:/opt/vertica/log \
+    --user $(perl -E '@s=stat "'"$PWD/log"'"; say "$s[4]:$s[5]"') \
+        vkconfig launch --conf /etc/vkconfig.conf &
+```
+The preceding command mounts the following files and directories in the scheduler container filesystem:
+- Local `vkconfig.conf` file in the container's `/etc` directory
+- Local `vkafka-log-config-debug.xml` file in the container's `/opt/vertica/packages/kafka/config` directory. This file structures log messages to help troubleshoot scheduler issues.
+- Local `/log` directory in the container's `/opt/vertica/log` directory to store logs to troubleshoot scheduler issues.
+
+Additionally, the command defines the following:
+- Passes the Docker `--user` command to define user that executes this `docker run` command as the default user within the scheduler container.
+- Executes the `vkconfig launch` command as a background process, passing the configuration file as an option.
+
+# Building a custom scheduler container
+
+In some circumstances, you might want to build a custom vertica/kafka-scheduler container. You can build a custom scheduler container if you have access to a Vertica binary and the associated Java libraries for your Vertica installation. By default, the Makefile assumes that you installed Vertica in the `/opt` directory. If you installed Vertica in a different directory, set the `VERTICA_INSTALL` configuration option when you build the container:
+
+```bash
+$ make build VERTICA_INSTALL=/path/to/vertica
+```
+
+## Build variables
+
+| Variable        | Description |
+|:----------------|:------------|
+| VERTICA_INSTALL | The location of your Vertica binary installation. Define this variable if you want to copy the local install of the Java libraries.<br>**Default**: `/opt/vertica`. |
+| VERTICA_VERSION | The Vertica version that you want to use to build the vkconfig container.<br>**Default**: `latest`.|
+| VERSION | ?????????? |
+
+# Repository contents overview
 
 This repository contains the following artifacts to help [test](#testing-the-container) and [build](#building-the-vertica-kafka-container) a vkconfig container
 
@@ -66,47 +183,6 @@ A bash script that configures and runs a scheduler with test data, and logs the 
 5. Displays the test data in the Flex table.
 6. Gracefully shuts down the scheduler.
 7. Removes the images pulled with the Compose file.
-
-
-
-## Testing the container
-
-If you build a 
-
-
-## Building the vertica-kafka container
-
-This repository provides a Makefile to build the vertica-kafka-scheduler with build conditions.
-
-When you build the container, the build process requires access to the Java libraries for your Vertica installation. By default, the Makefile assumes that you installed Vertica in the `/opt` directory. If you installed Vertica in a different directory, set the `VERTICA_INSTALL` configuration option when you build the container:
-
-```bash
-$ make build VERTICA_INSTALL=/path/to/vertica
-```
-
-### Build variables
-
-| Variable        | Description |
-|:----------------|:------------|
-| VERTICA_INSTALL | The location of your Vertica binary installation. Define this variable if you want to copy the local install of the Java libraries.<br>**Default**: `/opt/vertica`. |
-| VERTICA_VERSION | The Vertica version that you want to use to build the vkconfig container.<br>**Default**: `latest`.|
-| VERSION | ?????????? |
-
-## Environment setup
-
-### Configuration file 
-
-### Log configuration file 
-
-### Writable log directory 
-
-
-
-## Quickstart
-
-
-
-
 
 # Vertica-Kafka Scheduler
 

--- a/vertica-kafka-scheduler/README.md
+++ b/vertica-kafka-scheduler/README.md
@@ -30,7 +30,7 @@ For in-depth details about streaming data with Vertica and Apache Kafka, see [Ap
     - [Building a custom scheduler container](#building-a-custom-scheduler-container)
       - [Prerequisites](#prerequisites-1)
       - [`build` make target](#build-make-target)
-    - [Push to Docker Hub](#push-to-docker-hub)
+      - [Push to Docker Hub](#push-to-docker-hub)
 
 ## Prerequisites
 
@@ -69,7 +69,7 @@ To view runtime statistics on the scheduler, enter the following:
 $ docker run vertica/kafka-scheduler vkconfig statistics --help
 ```
 
-For in-depth details, see [Configuring a scheduler](#configure-a-scheduler).
+For in-depth details, see [Configuring a scheduler](#configure-a-scheduler-1).
 
 ### Launch a scheduler
 
@@ -84,7 +84,7 @@ $ docker run -it \
         vkconfig launch --conf /etc/vkconfig.conf &
 ```
 
-For in-depth details, see [Launch a scheduler](#launch-a-scheduler).
+For in-depth details, see [Launch a scheduler](#launch-a-scheduler-1).
 
 ### Scheduler demo
 
@@ -294,7 +294,7 @@ $ make build VERTICA_INSTALL=/path/to/vertica
 
 In addition to the build target and variables, the Makefile provides the `make java` and `make kafka` targets so that extract Java and Kafka installation files from your local Vertica installation. For details, see [Makefile](#makefile).
 
-### Push to Docker Hub
+#### Push to Docker Hub
 
 The Makefile has a `push` target that builds and pushes your custom scheduler container to [Docker Hub](https://hub.docker.com/):
 

--- a/vertica-kafka-scheduler/README.md
+++ b/vertica-kafka-scheduler/README.md
@@ -128,9 +128,24 @@ Additionally, the preceding command does the following:
 - Defines the `--user` with a Perl script that extracts the `/log` file owner and group information, and then formats those values in `user:group` format.
 - Executes `vkconfig launch` as a background process.
 
-# Building a custom scheduler container
+## Building a custom scheduler container
 
-In some circumstances, you might want to build a custom vertica/kafka-scheduler container. You can build a custom scheduler container if you have access to a Vertica binary and the associated Java libraries for your Vertica installation. By default, the Makefile assumes that you installed Vertica in the `/opt` directory. If you installed Vertica in a different directory, set the `VERTICA_INSTALL` configuration option when you build the container:
+In some circumstances, you might want to build a custom vertica/kafka-scheduler container. This repository provides a [Makefile](./Makefile) with a `build` target, and build variables that build a custom scheduler container that requires the following:
+- Vertica binary or rpm2cpio vertica.rpm | cpio -idmv and export VERTICA_INSTALL=./opt/vertica
+- Java SDK in `vertica/bin/VerticaSDK.jar`
+- Java version information in `vertica/sdk/BuildInfor.java`
+
+For additional information about Vertica and Java development, see [Java SDK](https://www.vertica.com/docs/latest/HTML/Content/Authoring/ExtendingVertica/Java/DevelopingInJava.htm).
+
+### `build` make target
+
+This repository provides a Makefile with a build target for creating a custom container:
+
+```bash
+$ make build
+```
+
+By default, the [Makefile](./Makefile) assumes that you installed Vertica in the `/opt` directory. If you installed Vertica in a different directory, set the `VERTICA_INSTALL` configuration option with the `build` target:
 
 ```bash
 $ make build VERTICA_INSTALL=/path/to/vertica
@@ -140,14 +155,22 @@ $ make build VERTICA_INSTALL=/path/to/vertica
 
 | Variable        | Description |
 |:----------------|:------------|
-| VERTICA_INSTALL | The location of your Vertica binary installation. Define this variable if you want to copy the local install of the Java libraries.<br>**Default**: `/opt/vertica`. |
-| VERTICA_VERSION | The Vertica version that you want to use to build the vkconfig container.<br>**Default**: `latest`.|
+| VERTICA_INSTALL | The location of your Vertica binary installation. Define this variable if you want to copy the local install of the Java libraries.<br>**Default**: `/opt/vertica` |
+| VERTICA_VERSION | The Vertica version that you want to use to build the scheduler container. The scheduler version must match the Vertica database version. <br>**Default**: `latest` |
 
-# Repository contents overview
+## Push to Docker Hub
+
+This repository provides the `push` make target that builds and pushes your custom scheduler container:
+
+```bash
+$ VERTICA_VERSION=latest make push
+```
+
+## Repository contents overview
 
 This repository contains the following artifacts to help [test](#testing-the-container) and [build](#building-the-vertica-kafka-container) a vkconfig container
 
-### Makefile
+## Makefile
 
 The Makefile contains the following targets:
 - `make help`: Displays the help for the Makefile.
@@ -158,7 +181,7 @@ The Makefile contains the following targets:
 - `make push`: Pushes the custom container image to the remote Docker Hub repository.
 - `make test`: Runs [example.sh](#examplesh) to validate the vkconfig configuration.
 
-### docker-compose.yaml
+## docker-compose.yaml
 
 A [Compose file](https://docs.docker.com/compose/compose-file/) that starts the following services, each as a container:
 - [Zookeeper](https://hub.docker.com/r/bitnami/zookeeper)
@@ -167,11 +190,11 @@ A [Compose file](https://docs.docker.com/compose/compose-file/) that starts the 
 
 The Compose file creates the `scheduler` network so that the containers can communicate with each other.
 
-### example.conf
+## example.conf
 
 A sample [configuration file](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/SettingUpAScheduler.htm#1). You can customize this file by replacing the default values or adding more [vkconfig script options](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/UtilityOptions/SharedUtilityOptions.htm).
 
-### example.sh
+## example.sh
 
 A bash script that configures and runs a scheduler with test data, and logs the entire process to the console. The process involves the following steps: 
 1. Sets up a test environment using the [docker-compose.yaml](#docker-composeyaml) file. The environment includes the following:
@@ -192,37 +215,3 @@ A bash script that configures and runs a scheduler with test data, and logs the 
 5. Displays the test data in the Flex table.
 6. Gracefully shuts down the scheduler.
 7. Removes the images pulled with the Compose file.
-
-# Vertica-Kafka Scheduler
-
-This github repo builds a Vertica-Kafka scheduler docker container for the
-purposes of streaming data from Kafka to Vertica.  It requires Docker or some
-compatible container environment.
-
-## Example
-`example.sh` is a full example of configuring and running a scheduler.  It uses
-docker-compose to create a kafka and vertica service, then it posts some kafka
-JSON messages, waits, then shows the messages in vertica tables.
-
-## Building docker container
-
-This is how you rebuild the docker image to customize it or update it and test it.
-This requres the vertica package installed in /opt/vertica or specified in the `make`
-command with `VERTICA_INSTALL=/wherever/opt/vertica`
-1. Clone this repository.
-2. Open a terminal in the `vertica-kafka-scheduler` directory.
-3. Install Vertica (or use rpm2cpio vertica.rpm |cpio -idmv and export VERTICA_INSTALL=./opt/vertica)
-4. Build the kafka scheduler container with
-    ```
-    make build
-    ```
-
-## Push to docker hub
-
-1. Clone this repository.
-2. Open a terminal in the `vertica-kafka-scheduler` directory.
-3. Install Vertica (or use rpm2cpio vertica.rpm |cpio -idmv and export VERTICA_INSTALL=./opt/vertica)
-4. Build and push containers
-    ```
-    VERTICA_VERSION=latest make push
-    ```

--- a/vertica-kafka-scheduler/README.md
+++ b/vertica-kafka-scheduler/README.md
@@ -248,8 +248,8 @@ vkconfig microbatch --add \
 After you [create a scheduler](#create-a-scheduler), launch the scheduler to begin scheduling microbatches. To launch a scheduler, execute a `docker run` command that does the following:
 - Mounts a configuration file as a volume.
 - Specifies the scheduler image name.
-- Mounts the `vkafka-log-config-debug.xml` file in the current directory into the container's `/opt/vertica/packages/kafka/config` directory. This file configures log messages to help troubleshoot scheduler issues.
-- Mounts `log` in the current directory into the container as the `/opt/vertica/log` directory. This writes log messages to the local `log` directory.
+- Mounts `vkafka-log-config-debug.xml` in the current directory into the container's `/opt/vertica/packages/kafka/config` directory. This file configures log messages to help troubleshoot scheduler issues.
+- Mounts `log` in the current directory into the container's `/opt/vertica/log` directory. This allows log messages to be written to the local `log` directory, assuming that `vkafka-log-config-debug.xml` configures log output in `/opt/vertica/log`.
 - Passes the Docker `--user` command to specify the UID that has write access on the `/log` directory.
 
 The following command provides an example format. Execute this command from the top-level directory of your cloned repository:

--- a/vertica-kafka-scheduler/README.md
+++ b/vertica-kafka-scheduler/README.md
@@ -53,7 +53,7 @@ The following command returns a list of all available options for a component:
 $ docker run vertica/kafka-scheduler vkconfig <component> --help
 ```
 
-For example, to view the description of each component in the microbatch, enter the following: 
+For example, to view the description of each `microbatch` option, enter the following: 
 
 ```bash
 $ docker run vertica/kafka-scheduler vkconfig microbatch --help

--- a/vertica-kafka-scheduler/README.md
+++ b/vertica-kafka-scheduler/README.md
@@ -88,7 +88,7 @@ For in-depth details, see [Launch a scheduler](#launch-a-scheduler).
 
 ### Scheduler demo
 
-This repository contains `example.sh`, a demonstration of a running scheduler. It creates a complete Vertica/Kafka environment, automatically loads JSON-formatted test data into a Flex table, logs each action to the console, and then removes any build artifacts. To run the demo, use the following command: 
+This repository contains `example.sh`, a demonstration of a running scheduler. It uses containers and Docker Compose to create a complete Vertica/Kafka environment, automatically loads JSON-formatted test data into a Flex table, logs each action to the console, and then removes any build artifacts. To run the demo, use the following command: 
 
 ```bash 
 $ make test

--- a/vertica-kafka-scheduler/README.md
+++ b/vertica-kafka-scheduler/README.md
@@ -73,7 +73,7 @@ For in-depth details, see [Configuring a scheduler](#configure-a-scheduler).
 
 ### Launch a scheduler
 
-To launch a scheduler, execute the following command from the top-level of this repository:
+To launch a scheduler, execute the following command from the `/vertica-kafka-scheduler` directory:
 
 ```bash
 $ docker run -it \
@@ -105,8 +105,8 @@ This repository contains the following utilities to help maintain and build a Ve
 The Makefile contains the following targets:
 - `make help`: Displays the help for the Makefile.
 - `make version`: Displays the Vertica version that will be used in the build process.
-- `make java`: Copy the local install of the Java libraries from `/opt/vertica/java` and saves them in a `/java` directory in the top-level of this repository.
-- `make kafka`: Copy the local install of the Kafka Scheduler from `/opt/vertica/packages/kafka` and saves them in a `/kafka` directory in the top-level of this repository.
+- `make java`: Copy the local install of the Java libraries from `/opt/vertica/java` and saves them in a `/java` directory in the `/vertica-kafka-scheduler` directory.
+- `make kafka`: Copy the local install of the Kafka Scheduler from `/opt/vertica/packages/kafka` and saves them in a `/kafka` directory in the `/vertica-kafka-scheduler` directory.
 - `make build`: Builds the container image.
 - `make push`: Pushes the custom container image to the remote Docker Hub repository.
 - `make test`: Runs [example.sh](#examplesh) to validate the vkconfig configuration.


### PR DESCRIPTION
@NerdLogic for review (I don't have the option on the right of this window to add you as a reviewer, so @'ing you here)

Updated repo-level and scheduler READMES:
- Added TOC
- Repo overview: summary of important files
- Quickstart: Important commands to config and launch scheduler
- Config and launch scheduler: Comprehensive instructions on how to config and launch scheduler
- Build custom container: Use make build to build a custom scheduler container
- Push to Docker Hub: make push to push to remote repo

NOTE: After revisions, it might make sense to move the following to the Docker Hub README:
- Intro
- Prereqs
- Installation
- Quickstart
- Links to GH repo