### PR TITLE
Udx vsdk vertica start db

### DIFF
--- a/UDx-container/Dockerfile_DEB
+++ b/UDx-container/Dockerfile_DEB
@@ -36,6 +36,9 @@ ARG dbadmin_id=1000
 ARG DEB
 ARG vertica_version
 
+ENV VERTICA_HOME_DIR="/home/$vertica_db_user"
+
+
 COPY $DEB /tmp/$DEB
 COPY ./tools/cleanup.sh /tmp/
 COPY ./tools/package-checksum-patcher.py /tmp/
@@ -97,7 +100,8 @@ RUN set -x \
                       -U
 
 RUN chown -R $vertica_db_user:$vertica_db_group $VERTICA_OPT_DIR \
-    && chown -R $vertica_db_user:$vertica_db_group /home/$vertica_db_user
+    && chown -R $vertica_db_user:$vertica_db_group ${VERTICA_HOME_DIR} \
+    && chmod 755 ${VERTICA_HOME_DIR}             
 
 # docker daemons versions < 19.03 don't preserve ownership on COPY --from
 # but doing the chown -R in the second half is costly in terms of
@@ -209,7 +213,8 @@ RUN set -x \
      # docker daemons versions < 19.03 don't preserve ownership on COPY --from
      # so we have to chown these things again
      && chown -R $vertica_db_user:$vertica_db_group ${VERTICA_DATA_DIR} \
-     && chown -R $vertica_db_user:$vertica_db_group /home/$vertica_db_user \
+     && chown -R $vertica_db_user:$vertica_db_group ${VERTICA_HOME_DIR} \
+     && chmod 755 ${VERTICA_HOME_DIR} \
      # but this chown is expensive in image-size, so we use aother
      # trick in the first half of the build 
      # && chown -R $vertica_db_user:$vertica_db_group ${VERTICA_OPT_DIR} \

--- a/UDx-container/Dockerfile_RPM
+++ b/UDx-container/Dockerfile_RPM
@@ -28,6 +28,8 @@ ARG vertica_db_group="verticadba"
 ARG dbadmin_gid=1000
 ARG dbadmin_id=1000
 
+ENV VERTICA_HOME_DIR="/home/$vertica_db_user"
+
 # name of .rpm file
 ARG RPM
 ARG vertica_version
@@ -115,7 +117,8 @@ RUN mkdir -p ${VERTICA_DATA_DIR} \
 COPY entrypoint.sh /opt/vertica/bin/entrypoint.sh
 
 RUN chown -R $vertica_db_user:$vertica_db_group ${VERTICA_OPT_DIR} \
-    && chown -R $vertica_db_user:$vertica_db_group /home/$vertica_db_user
+    && chown -R $vertica_db_user:$vertica_db_group ${VERTICA_HOME_DIR} \
+    && chmod 755 ${VERTICA_HOME_DIR}
 
 # docker daemons versions < 19.03 don't preserve ownership on COPY --from
 # but doing the chown -R in the second half is costly in terms of
@@ -251,7 +254,8 @@ RUN set -x \
      # docker daemons versions < 19.03 don't preserve ownership on COPY --from
      # so we have to chown these things again
      && chown -R $vertica_db_user:$vertica_db_group ${VERTICA_DATA_DIR} \
-         && chown -R $vertica_db_user:$vertica_db_group /home/$vertica_db_user \
+         && chown -R $vertica_db_user:$vertica_db_group ${VERTICA_HOME_DIR} \
+         && chmod 755 ${VERTICA_HOME_DIR} \
      # but this chown is expensive in image-size, so we use aother
      # trick in the first half of the build 
      # && chown -R $vertica_db_user:$vertica_db_group ${VERTICA_OPT_DIR} \

--- a/UDx-container/README.md
+++ b/UDx-container/README.md
@@ -178,6 +178,7 @@ In addition to the tools such as `vsdk-make` and `vsdk-g++`, there is a `vsdk-ve
 
 The UDx container itself is not writable, so it creates and mounts a Docker volume called `verticasdk-data`. It also mounts the current working directory and your home directory in the container using the same names those directories have on the host machine. In addition, `vsdk-vertica` understands the `VSDK_MOUNT` and `VSDK_ENV` environment variables described in [environment variables](#environment-variables).
 
+
 ## Fetching the test Vertica server startup log
 
 `vsdk-vertica` launches a server that runs in the background in a container named `verticasdk`.  You can read the container log using the `docker logs` command:

--- a/UDx-container/README.md
+++ b/UDx-container/README.md
@@ -181,11 +181,45 @@ The UDx container itself is not writable, so it creates and mounts a Docker volu
 
 ## Fetching the test Vertica server startup log
 
-`vsdk-vertica` launches a server that runs in the background in a container named `verticasdk`.  You can read the container log using the `docker logs` command:
+`vsdk-vertica` launches a server that runs in the background in a container named `verticasdk`.
+
+The command, when run, outputs the following message:
+
+```shell
+./vsdk-vertica
+Starting container...
+
+Run
+      docker logs verticasdk
+to view startup progress
+
+Don't stop container until above command prints 'Vertica is now running'
+To stop:
+    docker stop verticasdk
+
+When executing outside of a VWasm container, you can connect to this vertica
+using
+    vsql -p 11233
+
+If executing inside a VWasm container (where you did your Wasm development),
+just 'vsql' should suffice
+```
+
+As noted, you can read the container log using the `docker logs` command:
 
 ```shell
 docker logs verticasdk
 ```
+
+But also note the instructions for running vsql to talk to the Vertica in the vsdk-container:
+
+```shell
+When executing outside of a VSDK container, you can connect to this vertica
+using
+    vsql -p 11233 -U dbadmin
+```
+
+Outside the VSDK container the Vertica port is mapped to a non-standard port (in this case, `11233`).  The `-U dbadmin` connects to Vertica as the dbadmin user.  The database does not yet have any other users defined.  The dbadmin user has a blank password in this container's database, and has permission to manipulate UDx libraries in the container's database.
 
 ## Stopping and removing the test Vertica server
 

--- a/UDx-container/README.md
+++ b/UDx-container/README.md
@@ -24,6 +24,7 @@ Vertica provides a Dockerfile for different distributions so that you can create
 Vertica tests the following versions, but the contents of this repository might work with eariler versions:
 - 10.x
 - 11.x
+- 12.x
 
 ## CentOS
 - 7.9
@@ -52,7 +53,7 @@ You can include build variables in the build process to customize the container.
 |---------------------------|------------|
 | OSTAG | The container operating system distribution, either `centos` or `ubuntu`. This variable is required to build a container that runs an OS that is different from the host OS. |
 | PACKAGE | When there is more than one Vertica RPM or DEB file in the top-level directory, this variable specifies which file to use in the build process. |
-| TARGET | Required. The file type (RPM or DEB) of the Vertica binary that you use in the build process. |
+| TARGET | Required. The file type (`rpm` or `deb`) of the Vertica binary that you use in the build process. |
 | VERTICA_VERSION | The version number of the Vertica binary used in the build process. This value is optional for a [canonically-named Vertica binary](#building-with-a-canonically-named-vertica-binary).<br> You can use this variable to build containers for different Vertica versions. |
 
 For example, you might build multiple containers to develop UDxs for multiple Vertica versions. To help distinguish between containers, define `OSTAG` and `VERTICA_VERSION` in the build command. If you set `OSTAG=centos` and `VERTICA_VERSION=11.0.0-0`, the full container specification is `verticasdk:centos-11.0.0-0`.
@@ -94,7 +95,8 @@ This repository provides `vsdk-*` scripts to help you test and compile your UDx 
 | vsdk-g++ | Executes the g++ compiler in the UDx container. |
 | vsdk-make | Executes `make` in the current working directory in the UDx container. This allows you to develop UDxs locally and compile them with the tools available in the UDx container. |
 
-`vsdk-make` is the script that you will use the most often. It behaves exactly like `make`, but it compiles your files in the development environment mounted in the UDx container.
+`vsdk-make` is the script that you will probably
+use the most often. It behaves exactly like `make`, but it compiles your files in the development environment mounted in the UDx container.
 
 These scripts use the contents of `/etc/os-release` to determine whether the container has a `centos` or `ubuntu` tag. If your host uses a different distribution than your development environment, you can edit `vsdk-bash` directly to change the default setting. Alternatively, you can change the default interactively by defining the OSTAG [environment variable](#environment-variables) when you execute `vsdk-make`:
 

--- a/UDx-container/entrypoint.sh
+++ b/UDx-container/entrypoint.sh
@@ -104,10 +104,13 @@ function start_vertica() {
     # recreate that symlink
     preserve_config
     echo 'Starting Database'
-    ${ADMINTOOLS} -t start_db \
+    if ${ADMINTOOLS} -t start_db \
                   --database=$VERTICA_DB_NAME \
-                  --noprompts
-
+                  --noprompts; then
+        echo "Vertica is now running"
+    else
+        echo "Admintools was unable to start Vertica"
+    fi
 }
 
 # A container that runs Vertica hangs around until Vertica exits ---
@@ -122,8 +125,7 @@ case $vsdk_cmd in
         trap "shut_down" SIGKILL SIGTERM SIGHUP SIGINT
         initialize_vertica_directories
         start_vertica
-        echo "Vertica is now running"
-        
+       
         while [ "${STOP_LOOP}" == "false" ]; do
             # We could use admintools -t show_active_db to see if the
             # db is still running, and restart it if it isn't

--- a/UDx-container/vsdk-bash
+++ b/UDx-container/vsdk-bash
@@ -30,7 +30,7 @@
 #       /etc/os-release).
 # VERTICA_VERSION: something like 11.0.0-0
 #
-# In addition, there is these environment variables:
+# In addition, there are these environment variables:
 #
 # VSDK_MOUNT: an optional space-separated list of host directories to
 #       mount in the UDx container --- that is, "I'm going to want to
@@ -118,7 +118,23 @@ if [ "$VSDK_ENV"x != x ]; then
     VSDK_ENV_FILE_OPTION="--env-file $VSDK_ENV"
 fi
 
-user_id=`id -u`
+# sometimes it's useful to run vsdk-bash (especially) as dbadmin
+# e.g., to look at the vertica.log in the catalog directory
+case "$VSDK_USER"x in
+x)
+    user_id=`id -u`
+    ;;
+dbadminx)
+    user_id=1000
+    ;;
+*)
+    echo The only accepted VSDK_USER is dbadmin
+    echo "(the system defaults to yourself, otherwise)"
+    exit 1
+    ;;
+esac
+
+
 HOSTNAME=vsdk-$USER
 
 #         --env LD_LIBRARY_PATH=/opt/vertica/lib 

--- a/UDx-container/vsdk-vertica
+++ b/UDx-container/vsdk-vertica
@@ -127,8 +127,10 @@ while getopts "c:d:hi:r:t:v:V:" opt; do
 done
 CURDIR=`/bin/pwd`
 
+PORTOFFSET=$(( RANDOM % 10000 ))
+
 echo "Starting container..."
-docker run \
+if docker run \
        --security-opt=seccomp:unconfined \
        --privileged \
        -e PATH=$CONTAINER_PATH \
@@ -139,21 +141,28 @@ docker run \
        $VSDK_VOLUMES \
        $VSDK_ENV_FILE_OPTION \
        --mount type=volume,source=$DVOL,target=/data \
-       -p 5433:5433 \
-       -p 5444:5444 \
+       -p $(( PORTOFFSET + 5433 )):5433 \
+       -p $(( PORTOFFSET + 5444 )):5444 \
        -d \
        $VFLAG \
        --name $CONTAINER_NAME \
        $IMAGE_NAME:$TAG \
        ${CURDIR} \
        vertica
-echo
-
-echo
-echo "Run"
-echo "      docker logs $CONTAINER_NAME"
-echo "to view startup progress"
-echo
-echo "Don't stop container until above command prints 'Vertica is now running'"
-echo "To stop:"
-echo "    docker stop $CONTAINER_NAME"
+then
+    echo
+    echo "Run"
+    echo "      docker logs $CONTAINER_NAME"
+    echo "to view startup progress"
+    echo
+    echo "Don't stop container until above command prints 'Vertica is now running'"
+    echo "To stop:"
+    echo "    docker stop $CONTAINER_NAME"
+    echo
+    echo "When executing outside of a VWasm container, you can connect to this vertica"
+    echo "using"
+    echo "    vsql -p $(( PORTOFFSET + 5433 ))"
+    echo
+    echo "If executing inside a VWasm container (where you did your Wasm development),"
+    echo "just 'vsql' should suffice"
+fi

--- a/UDx-container/vsdk-vertica
+++ b/UDx-container/vsdk-vertica
@@ -159,9 +159,9 @@ then
     echo "To stop:"
     echo "    docker stop $CONTAINER_NAME"
     echo
-    echo "When executing outside of a VWasm container, you can connect to this vertica"
+    echo "When executing outside of a VSDK container, you can connect to this vertica"
     echo "using"
-    echo "    vsql -p $(( PORTOFFSET + 5433 ))"
+    echo "    vsql -p $(( PORTOFFSET + 5433 ))" -U dbadmin
     echo
     echo "If executing inside a VWasm container (where you did your Wasm development),"
     echo "just 'vsql' should suffice"


### PR DESCRIPTION
- Fix protection problems that had Vertica fail to start in the vsdk-vertica container
- Check status of admintools before blithely reporting that "Vertica is now running"
- To simplify use on shared systems, imported a feature from the Wasm-container work (map 5433 to (hopefully) unique port)

(Monica, added you as reviewer since you reported the bug, and so you can transform my prose in the README to readability.  If you have time.)