### PR TITLE
Add the --rm flag to docker run

### DIFF
--- a/UDx-container/vsdk-bash
+++ b/UDx-container/vsdk-bash
@@ -134,6 +134,7 @@ for arg in "$@"; do
 done
 
 docker run \
+       --rm \
        $INTERACTIVE \
        -e PATH=$CONTAINER_PATH \
        -e vUID=$user_id \


### PR DESCRIPTION
...to cause the temporary container it creates to be removed right after it's done.  Generally if you want a container to last, you give it a name rather than let docker chose a random name for it.  vsdk-vertica sets a container name, so I didn't add the --rm flag there, although I think it might be useful as well otherwise running it a second time might give an error.