### PR TITLE
Duane/odbc library

### DIFF
--- a/UDx-container/Dockerfile_DEB
+++ b/UDx-container/Dockerfile_DEB
@@ -198,6 +198,7 @@ RUN set -x \
             sysstat \
             tar \
             vim \
+            unixodbc-dev \
  && chsh -s /bin/bash root \
  && /bin/echo "en_US ISO-8859-1" > /etc/locale.gen \
  && /bin/echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \

--- a/UDx-container/Dockerfile_RPM
+++ b/UDx-container/Dockerfile_RPM
@@ -244,6 +244,8 @@ RUN set -x \
         readline-devel \
         sudo \
         tar \
+        vim \
+        unixODBC-devel \
         && yum clean all \
         && rm -rf /var/cache/yum \
      # Allow passwordless sudo access from dbadmin

--- a/UDx-container/vsdk-bash
+++ b/UDx-container/vsdk-bash
@@ -134,6 +134,7 @@ for arg in "$@"; do
 done
 
 docker run \
+       --rm \
        $INTERACTIVE \
        -e PATH=$CONTAINER_PATH \
        -e vUID=$user_id \


### PR DESCRIPTION
I'm not quite sure this is the right thing, but it would be convenient to the udx builders to provide some commonly used database packages to this container as long as it reduces the chances that they have to add any libraries to the image themselves.