### PR TITLE
Bugfix/ver 84624 ce image readm es refresh rjs

### DIFF
--- a/one-node-ce/README.md
+++ b/one-node-ce/README.md
@@ -20,8 +20,9 @@ Container techology provides the freedom to run environments independently of th
 Vertica provides a Dockerfile for different distributions so that you can create an containerized environment that you are the most comfortable with. This is helpful if you need to access a container shell to perform tasks, such as administering the database with [admintools](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/AdminTools/WritingAdministrationToolsScripts.htm).
 
 ## Vertica:
+- 12.x
 - 11.x
-- 10.x (beta)
+- 10.x
 
 ## CentOS
 - 8.3
@@ -31,98 +32,108 @@ Vertica provides a Dockerfile for different distributions so that you can create
 - 20.04
 - 18.04
 
-Vertica tests the CentOS containers most thoroughly.  Dockerfile_Ubuntu is provided for those who have a Vertica .deb file instead of a Vertica .rpm file, and can be adapted for recent versions of Debian.
+Vertica tests the CentOS containers most thoroughly. Vertica provides the [Dockerfile_Ubuntu](./Dockerfile_Ubuntu) for users that have only a Vertica DEB file. You can adapt that Dockerfile for recent versions of Debian.
 
-# Building the image
+# How to use this image
 
 ## Store the Vertica RPM or DEB
 
 To build an image using this repository, you must store your Vertica RPM or DEB archive in the `./packages` directory.
 
-If you do not have a Vertica RPM, register to download the free [Community Edition](https://www.vertica.com/try/) license. This is a limited license that allows you to create a three-node Vertica cluster with a maximum of 1TB of storage.
+If you do not have a Vertica archive, register to download the free [Community Edition](https://www.vertica.com/try/) (CE) license. The CE license allows you to create a three-node Vertica cluster with a maximum of 1TB of storage.
 
-## Build the image with `Makefile`
-This repository contains the `Makefile` script that creates an image with a [DBADMIN role](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PredefinedRoles.htm).
+## Build the image
 
-Export the following variables to customize the image properties:
+The repository [Makefile](./Makefile) creates an image with a [DBADMIN role](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PredefinedRoles.htm).
 
-| Environment Variable | Description | Default Values |
-| :--------------------| :-----------| :--------------|
-| TAG          | Required tag of the image. | latest |
-| IMAGE_NAME   | Required name of the image.| vertica-ce |
-| OS_TYPE      | Required OS Type.          | CentOS | 
-| OS_VERSION   | Required OS versions.      | CentOS: 7.9.2009<br> Ubuntu: 18.04 | 
-| VERTICA_PACKAGE | Name of the .rpm or .deb file | CentOS: vertica-x86_64.RHEL6.latest.rpm<br>Ubuntu: vertica.latest.deb |
-
-> **NOTE**: If the defaults are not be suitable for your environment, edit the `Makefile` to use more appropriate defaults.
-
-If you do not specify VERTICA_PACKAGE, and TAG is not set to `latest`, then the TAG must be the Vertica version because it is used to construct the version portion of the VERTICA_PACKAGE name.
-
-### Examples:
-```shell
-# Builds image with default values.
-make 
-
-# Builds image with custom image name and tag.
-make IMAGE_NAME=one-node-ce TAG=latest
-
-# Build image with Ubuntu base OS.
-make OS_TYPE=Ubuntu Tag=latest  
-
-# Build image with a non-default filename for the rpm.
-make VERTICA_PACKAGE=vertica-11.0.0.x86_64.RHEL6.rpm
-```
-
-## Build Custom image
-
-To customize build-time variables including the default database user, and group, and database name, export following optional variables:
+Export the following environment variables to customize image properties:
 
 | Environment Variable | Description | Default Values |
 | :--------------------| :-----------| :--------------|
-| VERTICA_DB_USER   | OS user and implicit database [superuser](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Privileges/AboutSuperuserPrivileges.htm).  | dbadmin |
-| VERTICA_DB_UID    | Vertica user uid.                        | 1000 |
-| VERTICA_DB_GROUP  | Group for database administrator users.  | verticadba | 
-| VERTICA_DB_NAME   | Vertica database name.                   | VMart | 
+| `TAG`          | Required. Image tag that represents the Vertica version. | `latest` |
+| `IMAGE_NAME`   | Required. Image name. | `vertica-ce` |
+| `OS_TYPE`      | Required. Operating system distribution.  | `CentOS` | 
+| `OS_VERSION`   | Required. Operatoring system versions. | CentOS: `7.9.2009`<br> Ubuntu: `18.04` | 
+| `VERTICA_PACKAGE` | Name of the RPM or DEB file. | CentOS: `vertica-x86_64.RHEL6.latest.rpm`<br>Ubuntu: `vertica.latest.deb` |
 
-### Example:
+> **Note**: You can edit the `Makefile` defaults to custom values for your environment.
+> If you do not specify `VERTICA_PACKAGE`, and `TAG` is not set to `latest`, then the `TAG` must be the Vertica version because it is used to construct the version portion of the `VERTICA_PACKAGE` name.
+
+#### Examples
+
+Default values:
 ```shell
-make IMAGE_NAME=one-node-ce TAG=latest VERTICA_DB_USER=vertica VERTICA_DB_UID=1200
+$ make
+```
+Custom image name and tag:
+```shell
+$ make IMAGE_NAME=one-node-ce TAG=latest
 ```
 
-After `Dockerfile_<distro>` installs the RPM or DEB file, it runs `tools/cleanup.sh`. `tools/cleanup.sh` trims the size of the distribution by removing less-commonly used files, and applies other file-size reduction techniques.
+Ubuntu base OS:
+```shell
+$ make
+```
 
-# Testing with ./run_tests.sh
+Custom RPM file name:
+```shell
+$ make VERTICA_PACKAGE=vertica-11.0.0.x86_64.RHEL6.rpm
+```
 
-After you build the container, you can test it with `make test` or with the `./run_tests.sh` script. The `./run_tests.sh` script verifies that the container can execute Vertica and some of the additional libraries.
+### Custom build-time variables
 
-> **IMPORTANT**: `./run_tests.sh` requires a [local copy of the vsql client](#getting-a-local-copy-of-vsql). 
+Export the following environment variables to customize the container at build-time:
 
-The `./run_tests.sh` script uses the normal Vertica port number, so you must stop any existing Vertica server (container or otherwise) on your test system before you test your container.
+| Environment Variable | Description | Default Values |
+| :--------------------| :-----------| :--------------|
+| `VERTICA_DB_USER`   | OS user and implicit database [superuser](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Privileges/AboutSuperuserPrivileges.htm).  | `dbadmin` |
+| `VERTICA_DB_UID`    | Vertica user uid.                        | `1000` |
+| `VERTICA_DB_GROUP`  | Group for database administrator users.  | `verticadba` | 
+| `VERTICA_DB_NAME`   | Vertica database name.                   | `VMart` | 
+
+#### Example
+
+```shell
+$ make IMAGE_NAME=one-node-ce TAG=latest VERTICA_DB_USER=vertica VERTICA_DB_UID=1200
+```
+### Reducing file size
+
+After `Dockerfile_<distro>` installs the RPM or DEB file, it runs `tools/cleanup.sh`. This script trims the size of the distribution by removing less-commonly used files, and applies other file-size reduction techniques.
+
+## Testing the container
+
+Test the container with the `run_tests.sh` script. You can use the `make test` target to run `run_tests.sh`, or you can run the script directly.
+
+### run_tests.sh
+The `run_tests.sh` script verifies that the container can execute Vertica and some of the additional libraries.
+
+> **IMPORTANT**: `run_tests.sh` requires a [local copy of the vsql client](#getting-a-local-copy-of-vsql). 
+
+The script uses the Vertica port number `5433`, so you must stop any existing Vertica server on your test system before you test your container.
 
 The test uses your image to create a new container with a unique tag and volume. Because the test sets up the optional libraries and creates the VMart database, creating a new container can take up to three minutes.
 
-If the tests pass, `All tests passed` appears at the end of the output, and the script exits with a 0 exit status. If the test fails with errors, the output contains `ERROR: <description>`, where `<description>` is a description of the error.
+If the tests pass, `All tests passed` is displayed at the end of the output, and the script exits with a `0` exit status. If the test fails with errors, the output contains `ERROR: <description>`, where `<description>` is a description of the error.
 
 You can run the script with the `-k` argument to retain the container and make it available for examination after testing:
 
 ```shell
-./run-test.sh -k
+$ ./run-test.sh -k
 ```
-
 When you are done with the container, you must manually remove it:
 
 ```shell
-docker stop vertica_ce_<suffix>
-docker rm vertica_ce_<suffix>
-docker volume rm vertica-test-<suffix>
+$ docker stop vertica_ce_<suffix>
+$ docker rm vertica_ce_<suffix>
+$ docker volume rm vertica-test-<suffix>
 ```
-In the previous command, `<suffix>` refers to the numeric suffix (the PID of the test-script shell that created the container and its volume). When used with the `-k` flag, `run-test.sh` prints out the above commands and populates `<suffix>`.
+In the previous command, `<suffix>` refers to the the PID of the test-script shell that created the container and its volume. When used with the `-k` flag, `run-test.sh` prints out the above commands and populates `<suffix>`.
 
-# How to use this image
+# Run a standalone Docker container
 
-## Start the Vertica server instance
+## Start with `start-vertica.sh`
 
-This repository contains the `start-vertica.sh` script with the following options:
+To simplify usage, this repository provides the `start-vertica.sh` script with the following options:
 
 ```shell
 Usage: ./start-vertica.sh [-c cname] [-d cid_dir] [-h] [-i img_name] [-t tag] [-v hostpath:containerdir] -V docker-volume
@@ -138,137 +149,138 @@ Options are:
  -V volume - docker volume to use for the Vertica database (default is vertica-data)
 ```
 
-> **NOTE**: By default, the container name is `vertica_ce`. Use this name to identify the container in your local Docker registry, with commands like `docker start` and `docker stop`.
+> **NOTE**: By default, the container name is `vertica_ce`. Use this name to identify the container in your local Docker registry with commands like `docker start` and `docker stop`.
 
 ### cid.txt file
 
-The `start-vertica.sh` script creates the **cid.txt** file, which stores the container ID within the container. By default, **cid.txt** is stored in current working directory. You can specify a directory to place the **cid.txt** file using the `-d cid_dir` option. For example, the following command places **cid.txt** in the home directory:
+The `start-vertica.sh` script creates the **cid.txt** file, which stores the container ID within the container. By default, **cid.txt** is stored in current working directory. You can specify a directory to place the **cid.txt** file using the `-d cid_dir` option. For example, the following command places **cid.txt** in the `/home` directory:
 
 ```shell
-start-vertica.sh -d /home
+$ start-vertica.sh -d /home
 ```
 > **NOTE**: You must have read and write access to the `cid_dir`.
 
 ## Start with `docker run`
 
-You can also use `docker run` to start the server instance. In the following example, `vertica-ce:latest` is the container image you created in [Building the image](#building-the-image):
+You can also use `docker run` to start the server instance. For example:
 
 ```shell
-docker run -p 5433:5433 \
+$ docker run -p 5433:5433 \
            --mount type=volume,source=vertica-data,target=/data \
            --name vertica_ce \
            vertica-ce:latest
 ```
-
+In the previous command:
+* `vertica-data` is a [Docker volume](https://docs.docker.com/storage/volumes/).
+* `vertica_ce` is the name of the container.
+* `vertica/vertica-ce` is the image name.
 
 ## Custom scripts
 
-The entrypoint script can run custom scripts during startup. You must store the scripts in a local directory named `.docker-entrypoint-initdb.d`. To make these scripts accessible by the entrypoint script, mount this directory in the container filesystem in `/docker-entrypoint-initdb.d/`. Scripts are executed in lexicographical order.
+The `docker-entrypoint.sh` script can run custom scripts during startup. You must store the scripts in a local directory named `.docker-entrypoint-initdb.d` and mount it in the container filesystem in `/docker-entrypoint-initdb.d/`. Scripts are executed in lexicographical order.
 
 Supported extensions include:
 - `sql`: SQL commands executed with vsql
 - `sh`: Shell scripts
 
-The following command creates a bind mount:
+The following command runs custom scripts with a [bind mount](https://docs.docker.com/storage/bind-mounts/):
 
 ```shell
-docker run -p 5433:5433 \
+$ docker run -p 5433:5433 \
            --mount type=bind,source=/tmp/.docker-entrypoint-initdb.d,target=/docker-entrypoint-initdb.d/ \
            --name vertica_ce \
            vertica-ce:latest
 ```
 
-For more information, see [Use bind mounts](https://docs.docker.com/storage/bind-mounts/) in the Docker documentation.
-
-## Container shell access
+## Access the container filesystem
 
 If you used the `start-vertica.sh` script to [start the server instance](#start-the-vertica-server-instance), use the `run-shell-in-container.sh` script to access a shell within a container. This script uses the **cid.txt** file that the `start-vertica.sh` creates to store the container ID. In the following command, `<cid_dir>` is the directory that stores **cid.txt**:
 
 ```shell
-./run-shell-in-container.sh [-d directory-for-cid.txt] [-n container-name] [-u uid] [-h ] [ ? ]
+$ ./run-shell-in-container.sh [-d directory-for-cid.txt] [-n container-name] [-u uid] [-h ] [ ? ]
 ```
 
-You must specify either `-d directory-for-cid.txt` or `-n container-name`. For example, `-n vertica_ce`.
+You must specify either `-d directory-for-cid.txt` or `-n container-name`. For example:
 
-`-u uid` specifies what user runs inside the container. Vertica recommends that you use DBADMIN_ID (default 1000), because that user has proper access to Vertica directories inside the container.
+```shell
+$ ./run-shell-in-container.sh -n vertica_ce
+```
+
+`-u uid` specifies the user account inside the container. Vertica recommends that you use `DBADMIN_ID` (default 1000), because that user has proper access to Vertica directories inside the container.
 
 > **NOTE**: If you have a [local copy](#getting-a-local-copy-of-vsql) of `vsql`, you do not need to access a container shell unless you need to use [admintools](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/AdminTools/WritingAdministrationToolsScripts.htm).
 
-Alternately, use the `docker exec` command to access a shell in the container. Using `docker exec` requires that you provide the container name:
+### Access with `docker exec`
+Alternatively, access a shell in the container with `docker exec`. `docker exec` requires that you provide the container name:
 
 ```shell
-docker exec -it <container name> bash -l
+$ docker exec -it <container name> bash -l
 ```
 
-After you access a shell, run `/opt/vertica/bin/vsql` to connect to the database and execute `vsql` commands on the files and volumes mounted in the container.
-
-You can access a container shell and vsql with a single command: 
-
+### Connect to the databse
+After you access a shell, run `/opt/vertica/bin/vsql` to connect to the database and execute `vsql` commands on the files and volumes mounted in the container. For example:
 ```shell
-docker exec -it <container_name> /opt/vertica/bin/vsql
+$ docker exec -it <container_name> /opt/vertica/bin/vsql
 ```
 
-## Viewing container logs
+## View container logs
 
-Fetch the container logs with the `docker logs` command. The following command uses **cid.txt**:
+Fetch the container logs with `docker logs`. The following command uses [cid.txt](#cidtxt-file):
 
 ```shell
-docker logs `cat cid.txt`
+$ docker logs `cat cid.txt`
 ```
-The following command fetches the logs for a container named **vertica_ce**:
+Fetch the logs for a container named **vertica_ce**:
 
 ```shell
-docker logs vertica_ce
+$ docker logs vertica_ce
 ```
-## Stopping the container
+## Stop the container
 
-Stop the container with the `docker stop` command. The following command uses **cid.txt**:
+Stop the container with `docker stop`. The following command uses [cid.txt](#cidtxt-file):
 
 ```shell
-docker stop `cat cid.txt`
+$ docker stop `cat cid.txt`
 ```
 The following command stops a container named **vertica_ce**:
 
 ```shell
-docker logs vertica_ce
+$ docker logs vertica_ce
 ```
 
-# External database access
+# Access the database with vsql or external client
 
 The container exposes port 5433 for external client access. To access the database from outside the container, you must have a [local copy of the vsql client](#getting-a-local-copy-of-vsql).
 
 ## Getting a local copy of vsql
 
-See [Client Drivers](https://www.vertica.com/download/vertica/client-drivers/) in Vertica Downloads to download all available client drivers.
+See [Client Drivers](https://www.vertica.com/download/vertica/client-drivers/) in to download all available client drivers.
 
-## Accessing the database
+## Access the database
 
 By default, the Dockerfile creates the `dbadmin` user in the container database. The following command accesses the database:
 ```shell
-vsql -U dbadmin
+$ vsql -U dbadmin
 ```
-You can configure the database user name with the `vertica_db_user` ARG variable in the Dockerfile or when you [build the custom image](#build-custom-image).
+You can configure the database user name with the `vertica_db_user` ARG variable in the Dockerfile or when you [build the image](#custom-build-time-variables).
 
 ## Persisting data
 
-This container mounts a Docker volume named **vertica-data** in the container as a persistent data store for the Vertica database. A Docker volume is used instead of a mounted host directory for the following reasons:
+This container mounts a [Docker volume](https://docs.docker.com/storage/volumes/) named `vertica-data` in the container to persist data for the Vertica database. A Docker volume is used instead of a mounted host directory for the following reasons:
+* Cross-platform acceptance. Docker volumes are compatible with Linux, MacOS, and Microsoft Windows. 
+* The container runs with different username to user-id mappings. A container with a mounted host directory might create files that you cannot inspect or delete because they are owned by a user that is determined by the Docker daemon. 
 
-- Cross-platform acceptance. Docker volumes are compatible with Linux, MacOs, and Microsoft Windows.
-- The container runs with different username to user-id mappings. A container with a mounted host directory might create files that you cannot inspect or delete because they are owned by a user that is determined by the Docker daemon.
-
-For details about managing volumes, see the [Docker documentation](https://docs.docker.com/storage/volumes/).
-
-> **NOTE**: Docker volumes live on the host filesystem as directories. These directories are created automatically and stored at `/var/lib/docker/volumes/`. Each volume is stored under `./volumename/_data/`. This might limit the amount of data you can store in your database if that directory is on a small filesystem.
+> **Note**: A Docker volume is represented on the host filesystem as a directory. These directories are created automatically and stored at `/var/lib/docker/volumes/`. Each volume is stored under `./volumename/_data/`. A small filesystem might might limit the amount of data you can store in your database.
 
 ## Extending the image
 
 The `dbadmin` user environment is extended to be user-friendly. For details, see the [vertica_env.sh](env_setup/vertica_env.sh) and [.vsqlrc](env_setup/.vsqlrc) scripts.
 
-## Environment Variables
+## Runtime configuration
 
-To configure various aspects of Vertica in container runtime, inject corresponding environment variables when executing the `docker run` command:
+To configure the Vertica container during runtime, inject environment variables when when you execute `docker run`:
 ```shell
-docker run -p 5433:5433 -d \
+$ docker run -p 5433:5433 -d \
   -e TZ='Europe/Prague' \
   vertica-ce:latest
 ```
@@ -276,10 +288,10 @@ The following table contains configurable environment variable parameters:
 
 | Environment Variable | Description | 
 | :--------------------| :-----------|
-| APP_DB_USER | Name of a database user, in addition to `vertica_db_user`. This user is created only when this variable is set. By default, this user is assigned [pseudosuperuser](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PSEUDOSUPERUSERRole.htm) privileges. |
-| APP_DB_PASSWORD | Password for APP_DB_USER. If this is omitted, the password is empty. |
-| TZ: "${VERTICA_CUSTOM_TZ:-Europe/Prague}" | The database time zone.<br><br>**IMPORTANT**: Vertica does not contain all timezones. Each Dockerfile contains a  commented-out workaround solution that begins "Link OS timezones". Uncomment the workaround to use time zones.<br>Setting the time zone with VERTICA_CUSTOM_TZ enables you to override it from your environment. |
-| DEBUG_FAILING_STARTUP | For development purposes. When you set the value to `y`, the entrypoint script does not end in case of failure, so you can investigate any failures. |
+| `APP_DB_USER` | Name of a database user, in addition to `vertica_db_user`. This user is created only when this variable is set. By default, this user is assigned [pseudosuperuser](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PSEUDOSUPERUSERRole.htm) privileges. |
+| `APP_DB_PASSWORD` | Password for `APP_DB_USER`. If this is omitted, the password is empty. |
+| `TZ`: "${VERTICA_CUSTOM_TZ:-Europe/Prague}" | The database time zone.<br><br>**IMPORTANT**: Vertica does not contain all timezones. Each Dockerfile contains a  commented-out workaround solution that begins "Link OS timezones". Uncomment the workaround to use time zones.<br>Setting the time zone with VERTICA_CUSTOM_TZ enables you to override it from your environment. |
+| `DEBUG_FAILING_STARTUP` | For development purposes. When you set the value to `y`, the entrypoint script does not end in case of failure, so you can investigate any failures. |
 
 # References and Contributions
 

--- a/one-node-ce/README.md
+++ b/one-node-ce/README.md
@@ -272,9 +272,6 @@ This container mounts a [Docker volume](https://docs.docker.com/storage/volumes/
 
 > **Note**: A Docker volume is represented on the host filesystem as a directory. These directories are created automatically and stored at `/var/lib/docker/volumes/`. Each volume is stored under `./volumename/_data/`. A small filesystem might might limit the amount of data you can store in your database.
 
-## Extending the image
-
-The `dbadmin` user environment is extended to be user-friendly. For details, see the [vertica_env.sh](env_setup/vertica_env.sh) and [.vsqlrc](env_setup/.vsqlrc) scripts.
 
 ## Runtime configuration
 

--- a/one-node-ce/README.md
+++ b/one-node-ce/README.md
@@ -94,11 +94,7 @@ $ make IMAGE_NAME=one-node-ce TAG=latest VERTICA_DB_USER=vertica VERTICA_DB_UID=
 ```
 ## Test the image
 
-After you [build the image](#build-the-image), test it with the [run_tests.sh](./run-tests.sh) script. You can use the `make test` target to run `run_tests.sh`, or you can run the script directly.
-
-> **IMPORTANT**: `run_tests.sh` requires a [local copy of the vsql client](#get-a-local-copy-of-vsql).
-
-`run_tests.sh` uses your image to create a new container with a unique tag and volume, then verifies that the container can execute Vertica and some additional libraries. Because the test configures optional libraries and creates the VMart database, creating a new container can take up to three minutes.
+After you [build the image](#build-the-image), test it with the [run_tests.sh](./run-tests.sh) script. You can use the `make test` target to run `run_tests.sh`, or you can run the script directly
 
 > **IMPORTANT**: The script uses the Vertica port number `5433`. You must stop any existing Vertica server on your test system before you test your container.
 
@@ -106,9 +102,7 @@ After you [build the image](#build-the-image), test it with the [run_tests.sh](.
 
 Passing tests: `All tests passed` is displayed at the end of the output, and the script exits with a `0` exit status.
 
-Failed tests: The output describes the error in the following format: `ERROR: <description>`.
-
-### Debug errors
+Failed tests: The output describes the error in the following format: `ERROR: <d#customize-the-vertica-useror
 
 You can run the script with the `-k` argument to retain the container and examine it after testing:
 
@@ -173,7 +167,8 @@ In the preceding command:
 
 ### Runtime configuration
 
-To configure the Vertica container during runtime, inject environment variables when when you execute `docker run`:
+When you execute `docker run`, you can inject environment variables at runtime:
+
 ```shell
 $ docker run -p 5433:5433 -d \
   -e TZ='Europe/Prague' \
@@ -206,12 +201,7 @@ $ docker run -p 5433:5433 \
            vertica-ce:latest
 ```
 
-# Access the container filesystem
-
-> **NOTE**: If you have a [local copy](#get-a-local-copy-of-vsql) of `vsql`, you do not need to access a container shell unless you need to use [admintools](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/AdminTools/WritingAdministrationToolsScripts.htm).
-
-## Access with `run-shell-in-container.sh`
-
+# Access the container filesysteof `vsql`, you do not need to access a container shell unless you need to use [admintools](https://www.vertica.com/docs/latest/HTML/Content/Author
 If you used the `start-vertica.sh` script to [start the server instance](#start-the-vertica-server-instance), use the `run-shell-in-container.sh` script to access a shell within a container:
 
 ```shell
@@ -219,7 +209,7 @@ $ ./run-shell-in-container.sh [-d cid_dir] [-n container-name] [-u uid] [-h ] [ 
 ```
 In the preceding command:
 - `-d cid_dir` is the [cid.txt](#cidtxt-file) file that the `start-vertica.sh` creates to store the container ID.
-- `-u uid` specifies the user account inside the container. Vertica recommends that you use `DBADMIN_ID` (default 1000), because [DBADMIN](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PredefinedRoles.htm) has proper access to Vertica directories inside the container.
+- `-u uid` specifies the user account inside the container. Vertica recommends that you use `DBADMIN_ID` (default 1000), because [DBADMIN](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PredefinedRoles.htm) has proper access to #customize-the-vertica-userhecontainer.
 
 You must specify either `-d directory-for-cid.txt` or `-n container-name`. For example:
 
@@ -253,23 +243,20 @@ After you [access a shell](#access-the-container-filesystem), run `/opt/vertica/
 $ docker exec -it <container_name> /opt/vertica/bin/vsql
 ```
 
-## External vsql or external client
+## External vsql or client
 
-The container exposes port 5433 for external client access. To access the database from outside the container, you must have a [local copy of the vsql client](#get-a-local-copy-of-vsql).
+Before you can access a Vertica database from outside the container, you must install a local copy of vsql. To download vsql and all available drivers, see [Client Drivers](https://www.vertica.com/download/vertica/client-drivers/).
 
-### Get a local copy of vsql
+The container exposes port `5433` for external client access.
 
-To download vsql and all available drivers, see [Client Drivers](https://www.vertica.com/download/vertica/client-drivers/).
-
-### Access the database
+## Access the database
 
 By default, the Dockerfile creates the `dbadmin` user in the container database. The following command accesses the database:
 
 ```shell
 $ vsql -U dbadmin
 ```
-You can configure the database user name with the `VERTICA_DB_USER` ARG variable in the Dockerfile or when you [build the image](#custom-build-time-variables).
-
+You can configure the database user name with the `VERTICA_DB_USER` ARG variable in the Dockerfile or when you [build the image](#customize-the-vertica-user).
 
 ## View container logs
 
@@ -293,9 +280,6 @@ $ docker stop `cat cid.txt`
 # Stop a container named vertica_ce
 $ docker stop vertica_ce
 ```
-
-
-
 
 # References and Contributions
 

--- a/one-node-ce/README.md
+++ b/one-node-ce/README.md
@@ -201,7 +201,12 @@ $ docker run -p 5433:5433 \
            vertica-ce:latest
 ```
 
-# Access the container filesysteof `vsql`, you do not need to access a container shell unless you need to use [admintools](https://www.vertica.com/docs/latest/HTML/Content/Author
+# Access the container filesystem
+
+> If you have a local copy of `vsql`, you do not need to access a container shell unless you need to use [admintools](https://www.vertica.com/docs/latest/HTML/Content/Author
+
+## Access with `run-shell-in-container.sh`
+
 If you used the `start-vertica.sh` script to [start the server instance](#start-the-vertica-server-instance), use the `run-shell-in-container.sh` script to access a shell within a container:
 
 ```shell

--- a/one-node-ce/README.md
+++ b/one-node-ce/README.md
@@ -102,7 +102,9 @@ After you [build the image](#build-the-image), test it with the [run_tests.sh](.
 
 Passing tests: `All tests passed` is displayed at the end of the output, and the script exits with a `0` exit status.
 
-Failed tests: The output describes the error in the following format: `ERROR: <d#customize-the-vertica-useror
+Failed tests: The output describes the error in the following format: `ERROR: <description>`.
+
+### Debug errors
 
 You can run the script with the `-k` argument to retain the container and examine it after testing:
 
@@ -203,7 +205,7 @@ $ docker run -p 5433:5433 \
 
 # Access the container filesystem
 
-> If you have a local copy of `vsql`, you do not need to access a container shell unless you need to use [admintools](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/AdminTools/WritingAdministrationToolsScripts.htm)
+> If you have a [local copy of vsql](#external-vsql-or-client), you do not need to access a container shell unless you need to use [admintools](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/AdminTools/WritingAdministrationToolsScripts.htm)
 
 ## Access with `run-shell-in-container.sh`
 

--- a/one-node-ce/README.md
+++ b/one-node-ce/README.md
@@ -209,14 +209,14 @@ $ docker run -p 5433:5433 \
 
 ## Access with `run-shell-in-container.sh`
 
-If you used the `start-vertica.sh` script to [start the server instance](#start-the-vertica-server-instance), use the `run-shell-in-container.sh` script to access a shell within a container:
+If you used the `start-vertica.sh` script to [start the container](#start-with-start-verticash), use the `run-shell-in-container.sh` script to access a shell within a container:
 
 ```shell
 $ ./run-shell-in-container.sh [-d cid_dir] [-n container-name] [-u uid] [-h ] [ ? ]
 ```
 In the preceding command:
 - `-d cid_dir` is the [cid.txt](#cidtxt-file) file that the `start-vertica.sh` creates to store the container ID.
-- `-u uid` specifies the user account inside the container. Vertica recommends that you use `DBADMIN_ID` (default 1000), because [DBADMIN](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PredefinedRoles.htm) has proper access to #customize-the-vertica-userhecontainer.
+- `-u uid` specifies the user account inside the container. Vertica recommends that you use `DBADMIN_ID` (default 1000), because [DBADMIN](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/DBADMINRole.htm) has proper access to #customize-the-vertica-userhecontainer.
 
 You must specify either `-d directory-for-cid.txt` or `-n container-name`. For example:
 

--- a/one-node-ce/README.md
+++ b/one-node-ce/README.md
@@ -203,7 +203,7 @@ $ docker run -p 5433:5433 \
 
 # Access the container filesystem
 
-> If you have a local copy of `vsql`, you do not need to access a container shell unless you need to use [admintools](https://www.vertica.com/docs/latest/HTML/Content/Author
+> If you have a local copy of `vsql`, you do not need to access a container shell unless you need to use [admintools](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/AdminTools/WritingAdministrationToolsScripts.htm)
 
 ## Access with `run-shell-in-container.sh`
 

--- a/one-node-ce/dockerhub.md
+++ b/one-node-ce/dockerhub.md
@@ -1,7 +1,7 @@
 
 # About
 
-This is a single-node Docker [Community Edition](https://www.vertica.com/docs/latest/HTML/Content/Authoring/GettingStartedGuide/DownloadingAndStartingVM/DownloadingAndStartingVM.htm) image for Vertica. The base OS for the image is CentOS7.9.2009 with a Vertica Version 11.1.0-0 CE.
+This is a single-node Docker image of the [Vertica Community Edition](https://www.vertica.com/docs/latest/HTML/Content/Authoring/GettingStartedGuide/DownloadingAndStartingVM/DownloadingAndStartingVM.htm).
 
 # Supported Tags
 
@@ -26,71 +26,77 @@ https://www.vertica.com/
 
 # Supported Platforms
 
-Container techology provides the freedom to run environments independently of the host operating system. This image has only been tested with CentOS. Further testing is ongoing.
+This image has been tested with CentOS. Further testing is ongoing.
 
 # How to Use This Image
 
-## Run a standalone docker container:
-You can use `docker run`. In the following example, `vertica/vertica-ce` is the container image you pulled:
+To simplify usage, this image provides the following configurations:
+- [VMart example database](https://www.vertica.com/docs/latest/HTML/Content/Authoring/GettingStartedGuide/IntroducingVMart/IntroducingVMart.htm)
+* [DBADMIN](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PredefinedRoles.htm) database user account
+* `verticadba` database group
+
+> **Note**: By default, there is no database password.
+
+## Run a standalone Docker container
+
+Start a container with `docker run`:
 
 ```sh
-docker run -p 5433:5433 -p 5444:5444 \
+$ docker run -p 5433:5433 -p 5444:5444 \
            --mount type=volume,source=vertica-data,target=/data \
            --name vertica_ce \
            vertica/vertica-ce
 ```
 
 In the previous command:
-* `vertica_ce` is the name of the container.
 * `vertica-data` is a [Docker volume](https://docs.docker.com/storage/volumes/).
+* `vertica_ce` is the name of the container.
+* `vertica/vertica-ce` is the image name.
 
-The image provides the following configurations to simplify usage:
-* A pre-built sample database named **VMart**
-* Database user account named **dbadmin**
-* Database group named **verticadba**
 
-> **Note**: By default, there is no database password.
+## Access the container filesystem
 
-## Access the container:
+Open a `bash` shell in a running container:
 ```sh
-docker exec -it <container name> bash -l
+$ docker exec -it <container name> bash -l
 ```
 After you access a shell, run `/opt/vertica/bin/vsql` to connect to the database and execute vsql commands on the files and volumes mounted in the container. By default, an example schema named `VMart` is loaded into the database.
 
-You can access a container shell and vsql with a single command:
+Access a container shell and vsql with a single command:
 ```sh
-docker exec -it <container_name> /opt/vertica/bin/vsql
+$ docker exec -it <container_name> /opt/vertica/bin/vsql
 ```
 
-## Access the database via vsql/client:
+## Access the database with vsql or external client
 
-The `5433` and`5444` ports will be mapped to your host, which means you need to leave these ports unoccupied.
+The `5433` and`5444` ports are mapped to your host, so leave these ports unoccupied.
 
 You can then access the database in one of the following ways:
 - vsql on the container
 - vsql on the host
 - An external client using the `5433` and`5444` port
 
-## Persisting data:
-This container mounts a Docker volume named `vertica-data` in the container as a persistent data store for the Vertica database. A Docker volume is used instead of a mounted host directory for the following reasons:
+## Persisting data
+
+This container mounts a [Docker volume](https://docs.docker.com/storage/volumes/) named `vertica-data` in the container to persist data for the Vertica database. A Docker volume is used instead of a mounted host directory for the following reasons:
 * Cross-platform acceptance. Docker volumes are compatible with Linux, MacOS, and Microsoft Windows. 
 * The container runs with different username to user-id mappings. A container with a mounted host directory might create files that you cannot inspect or delete because they are owned by a user that is determined by the Docker daemon. 
 
+> **Note**: A Docker volume is represented on the host filesystem as a directory. These directories are created automatically and stored at `/var/lib/docker/volumes/`. Each volume is stored under `./volumename/_data/`. A small filesystem might might limit the amount of data you can store in your database.
 
-> **Note**: Docker volumes live on the host filesystem as directories. These directories are created automatically and stored at `/var/lib/docker/volumes/`. Each volume is stored under `./volumename/_data/`. This might limit the amount of data you can store in your database if that directory is on a small filesystem.
+### Bind mounts
 
-You might also use a bind mount to another directory that is mounted on a sufficient disk, if you dont want to use docker volumes:
+As an alternative to a Docker volume, you can use a [bind mount](https://docs.docker.com/storage/bind-mounts/) to persist data to another directory with sufficient disk space:
 ```sh
-docker run -p 5433:5433 -p 5444:5444\
+$ docker run -p 5433:5433 -p 5444:5444\
            --mount type=bind,source=/<directory>,target=/data \
            --name vertica_ce \
            vertica/vertica-ce
 ```
-Make sure the user running `docker run` has read and write privileges on the source directory.
+> **Important**: The user that executes `docker run` must have read and write privileges on the source directory.
 
-## Use with Docker Compose:
-
-You can use the Docker image in with docker-compose. The following is an example YAML file:
+## Docker Compose
+Define a multi-container application with a `docker-compose` YAML file. For example:
 ```yaml
 version: "3.9"
 services:
@@ -114,12 +120,11 @@ volumes:
   vertica-data2:
 ```
 
-Run `docker-compose up`:
+To run the configuration, run `docker-compose up`:
 ```sh
-docker-compose --file ./docker-compose.yml --project-directory <directory_name> up -d
+$ docker-compose --file ./docker-compose.yml --project-directory <directory_name> up -d
 ```
-
-> **Note**: We have not tested this integration, so we do not have network setup recommendations.
+> **Note**: The Docker Compose integration is not tested, so there are no network setup recommendations.
 
 
 ## License:

--- a/one-node-ce/dockerhub.md
+++ b/one-node-ce/dockerhub.md
@@ -76,15 +76,15 @@ You can then access the database in one of the following ways:
 - vsql on the host
 - An external client using the `5433` and`5444` port
 
-## Persisting data
+# Persistence
 
-This container mounts a [Docker volume](https://docs.docker.com/storage/volumes/) named `vertica-data` in the container to persist data for the Vertica database. A Docker volume is used instead of a mounted host directory for the following reasons:
+This container mounts a [Docker volume](https://docs.docker.com/storage/volumes/) named `vertica-data` to persist data for the Vertica database. A Docker volume provides the following advantages over a mounted host directory:
 * Cross-platform acceptance. Docker volumes are compatible with Linux, MacOS, and Microsoft Windows. 
 * The container runs with different username to user-id mappings. A container with a mounted host directory might create files that you cannot inspect or delete because they are owned by a user that is determined by the Docker daemon. 
 
 > **Note**: A Docker volume is represented on the host filesystem as a directory. These directories are created automatically and stored at `/var/lib/docker/volumes/`. Each volume is stored under `./volumename/_data/`. A small filesystem might might limit the amount of data you can store in your database.
 
-### Bind mounts
+## Bind mounts
 
 As an alternative to a Docker volume, you can use a [bind mount](https://docs.docker.com/storage/bind-mounts/) to persist data to another directory with sufficient disk space:
 ```sh
@@ -95,7 +95,8 @@ $ docker run -p 5433:5433 -p 5444:5444\
 ```
 > **Important**: The user that executes `docker run` must have read and write privileges on the source directory.
 
-## Docker Compose
+# Docker Compose
+
 Define a multi-container application with a `docker-compose` YAML file. For example:
 ```yaml
 version: "3.9"
@@ -127,6 +128,6 @@ $ docker-compose --file ./docker-compose.yml --project-directory <directory_name
 > **Note**: The Docker Compose integration is not tested, so there are no network setup recommendations.
 
 
-## License:
+# License
 
 View the [license information](https://www.microfocus.com/en-us/legal/software-licensing) for this image.

--- a/one-node-ce/dockerhub.md
+++ b/one-node-ce/dockerhub.md
@@ -48,7 +48,7 @@ $ docker run -p 5433:5433 -p 5444:5444 \
            vertica/vertica-ce
 ```
 
-In the previous command:
+In the preceding command:
 * `vertica-data` is a [Docker volume](https://docs.docker.com/storage/volumes/).
 * `vertica_ce` is the name of the container.
 * `vertica/vertica-ce` is the image name.


### PR DESCRIPTION
Refactored README and dockerhub.md files:
- standard copy edits
- reorganized sections to mimic real-world usage. For example, put "Stop the container" at the end...
- removed vsql default section
- removed section explaining cleanup script that deletes build artifacts after building the image

Please look at the "Runtime configuration" section. The previous version said that these env var options are available only when you use `docker run`