### PR TITLE
Bugfix/readme copy edits rjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ For Vertica on Kubernetes containers and resources, see [vertica-kubernetes](htt
 
 ## [One-Node CE](https://github.com/vertica/vertica-containers/tree/main/one-node-ce)
 
-The One-Node CE directory provides instructions to build the containerized version of the [Vertica Community Edition (CE)](https://www.vertica.com/landing-page/start-your-free-trial-today/), a free, limited license that Vertica provides users as a hands-on introduction to the platform. For an overview, see the [Vertica documentation](https://www.vertica.com/docs/latest/HTML/Content/Authoring/GettingStartedGuide/DownloadingAndStartingVM/DownloadingAndStartingVM.htm).
+The One-Node CE directory provides instructions to build the containerized version of the [Vertica Community Edition (CE)](https://www.vertica.com/landing-page/start-your-free-trial-today/), a free, limited license that Vertica provides as a hands-on introduction to the platform. For an overview, see the [Vertica documentation](https://www.vertica.com/docs/latest/HTML/Content/Authoring/GettingStartedGuide/DownloadingAndStartingVM/DownloadingAndStartingVM.htm).
 
 Vertica publishes the binary version of this container on [DockerHub](https://hub.docker.com/u/vertica) as the [vertica/vertica-ce](https://hub.docker.com/r/vertica/vertica-ce) container.
 
 
 ## [UDx-container](https://github.com/vertica/vertica-containers/tree/main/UDx-container)
 
-The UDx-container directory packages in a container the following resources required to build User-Defined eXtensions:
+The UDx-container directory packages in a container the following resources required to build User-Defined eXtensions (UDxs):
 - C++-compiler
 - Libraries
 - Google protobuf compiler
@@ -26,7 +26,7 @@ The UDx-container directory packages in a container the following resources requ
 
 ## [Kafka Scheduler](vertica-kafka-scheduler)
 
-The kafka-scheduler directory provides tools to maintain a the official [vertica/kafka-scheduler](https://hub.docker.com/r/vertica/kafka-scheduler) container, or build a custom containerized version of the [Vertica Kafka Scheduler](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/AutomaticallyCopyingDataFromKafka.htm), a standalone Java application that automatically consumes data from one or more Kafka topics and then loads the structured data into Vertica.
+The kafka-scheduler directory provides tools to maintain the official [vertica/kafka-scheduler](https://hub.docker.com/r/vertica/kafka-scheduler) container, or build a custom containerized version of the [Vertica Kafka Scheduler](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/AutomaticallyCopyingDataFromKafka.htm), a standalone Java application that automatically consumes data from one or more Kafka topics and then loads the structured data into Vertica.
 
 The Kafka Scheduler provides the following advantages over manually loading data with COPY statements:
 - Streamed data automatically loads in your database according to the [frame duration](https://www.vertica.com/docs/latest/HTML/Content/Authoring/KafkaIntegrationGuide/ChoosingFrameDuration.htm).

--- a/UDx-container/README.md
+++ b/UDx-container/README.md
@@ -9,10 +9,10 @@ This repository creates an image that provides tools to develop C++ User-Defined
 For additional details about developing Vertica UDxs, see [Extending Vertica](https://www.vertica.com/docs/latest/HTML/Content/Authoring/ExtendingVertica/ExtendingVertica.htm).
 
 ## Prerequisites
-- [Docker Desktop](https://www.docker.com/get-started) or [Docker Engine](https://docs.docker.com/engine/install/).
-- Vertica RPM or DEB file.
-- vsql driver and other applicable [client libraries](https://www.vertica.com/download/vertica/client-drivers/).
-- [Python 3](https://www.python.org/downloads/).
+- [Docker Desktop](https://www.docker.com/get-started) or [Docker Engine](https://docs.docker.com/engine/install/)
+- Vertica RPM or DEB file
+- vsql driver and other applicable [client libraries](https://www.vertica.com/download/vertica/client-drivers/)
+- [Python 3](https://www.python.org/downloads/)
 
 # Supported Platforms
 
@@ -37,25 +37,25 @@ Vertica tests the following versions, but the contents of this repository might 
 
 # Overview
 
-The Vertica UDx container packages the binaries, libraries, and compilers required to create C++ Vertica UDx extensions. Use this repository with your Vertica binary to develop UDxs on any host system that meets the [prerequisites](#prerequisites).
+The Vertica UDx container packages the binaries, libraries, and compilers required to create C++ Vertica UDx extensions. Use this repository with your Vertica binary to develop UDxs on any host system that meets the [Prerequisites](#prerequisites).
 
 In addition, this repository provides `vsdk-*` commmand line tools to simplify the development process. You can develop UDxs on your host machine, compile them within the UDx container, and then save the object files on your host machine to load into Vertica.
 
-Of special note is the `vsdk-vertica` command which launches a container with a running Vertica instance. You can use this container to load and test your UDx.
+For example, the `vsdk-vertica` command launches a container with a running Vertica instance. You can use this container to load and test your UDx.
 
 # Building the UDx container
 
-Use the repository [Makefile](Makefile) to build your container. The Makefile requires that you store a Vertica RPM or DEB file in the top level of the UDx-container directory of your cloned repository. The container inherits the privileges and user ID from the user executing the container.
+Use the repository [Makefile](Makefile) to build your container. The `Makefile` requires that you store a Vertica RPM or DEB file in the top level of the `UDx-container/` directory in your cloned repository. The container inherits the privileges and user ID from the user executing the container.
 
 ## Build variables
 
 You can include build variables in the build process to customize the container. The following table describes the available variables:
 
 | Name                      | Definition |
-|---------------------------|------------|
+|:--------------------------|:-----------|
 | `OSTAG` | The container operating system distribution, either `centos` or `ubuntu`. This variable is required to build a container that runs an OS that is different from the host OS. |
 | `PACKAGE` | When there is more than one Vertica RPM or DEB file in the top-level directory, this variable specifies which file to use in the build process. |
-| `TARGET` | Required. The file type (`rpm` or `deb`) of the Vertica binary that you use in the build process. |
+| `TARGET` | Required. The file type of the Vertica binary that you use in the build process.<br>Accepts `rpm` or `deb`. |
 | `VERTICA_VERSION` | The version number of the Vertica binary used in the build process. This value is optional for a [canonically-named Vertica binary](#building-with-a-canonically-named-vertica-binary).<br> You can use this variable to build containers for different Vertica versions. |
 
 You might build multiple containers to develop UDxs for multiple Vertica versions. To help distinguish between containers, define `OSTAG` and `VERTICA_VERSION` in the build command. If you set `OSTAG=centos` and `VERTICA_VERSION=11.0.0-0`, the full container specification is `verticasdk:centos-11.0.0-0`.
@@ -72,7 +72,7 @@ $ vertica-10.1.1-5.x86_64.RHEL6.rpm
 $ vertica_10.0.1-5_amd64.deb
 ```
 
-The `Makefile` extracts the Vertica version (10.1.1-5) and the OS distribution version (RHEL 6). If the Vertica binary uses this format, run `make` with the `TARGET` variable to build the container. For example, the following command builds a UDx container with a canonically-named RPM file:
+The `Makefile` extracts the Vertica version (`10.1.1-5`) and the OS distribution version (`RHEL6`). If the Vertica binary uses this format, run `make` with the `TARGET` variable to build the container. For example, the following command builds a UDx container with a canonically-named RPM file:
 
 ```shell
 $ make TARGET=rpm
@@ -91,14 +91,13 @@ $ make TARGET=deb VERTICA_VERSION=11.0.0-0
 This repository provides `vsdk-*` scripts to help you test and compile your UDx in a multi-environment compilation. You invoke the following scripts on your host machine, and they execute in the UDx container:
 
 | Script&nbsp;name | Description |
-|-------------|-------------|
+|:-----------------|:------------|
 | `vsdk-bash` | Opens a bash shell in the UDx container. This script is useful for debugging. |
 | `vsdk-cp` | Invokes `cp` inside the UDx container. This is a helper script used in the `make test` command, and included because the UDx container is not writable and you might need to copy UDx files to your host for editing. |
 | `vsdk-g++` | Executes the g++ compiler in the UDx container. |
 | `vsdk-make` | Executes `make` in the current working directory in the UDx container. This allows you to develop UDxs locally and compile them with the tools available in the UDx container. |
 
-`vsdk-make` is the script that you will probably
-use the most often. It behaves exactly like `make`, but it compiles your files in the development environment mounted in the UDx container.
+You will likely use `vsdk-make` the most often. It behaves exactly like `make`, but it compiles your files in the development environment mounted in the UDx container.
 
 These scripts use the contents of `/etc/os-release` to determine whether the container has a `centos` or `ubuntu` tag. If your host uses a different distribution than your development environment, you can edit `vsdk-bash` directly to change the default setting. Alternatively, you can change the default interactively by defining the OSTAG [environment variable](#environment-variables) when you execute `vsdk-make`:
 
@@ -108,10 +107,10 @@ $ OSTAG=ubuntu vsdk-make
 
 ## Environment variables
 
-Use environment variables to provide additional information to the `vsdk-*` commands. The following table defines the avaiable environment variables:
+The following table describes the environment variables that you can set to provide additional information to the `vsdk-*` commands:
 
-| Environment&nbsp;Variable | Definition |
-|---------------------------|------------|
+| Environment&nbsp;Variable | Description |
+|:--------------------------|:------------|
 | `OSTAG` | The container operating system distribution, either `centos` or `ubuntu`. This variable is if you use a container that runs an OS that is different from the host OS. If you do not define this variable, `vsdk-make` reads `/etc/os-release` to determine the OS. |
 | `VERTICA_VERSION` | The version number of the Vertica binary used in the build process. |
 | `VSDK_ENV` | Optional file that defines environment variables for `vsdk-*` commands that run in the container. For formatting details, see [Declare default environment variables in file](https://docs.docker.com/compose/env-file/) in the Docker documentation.|
@@ -124,7 +123,7 @@ After you [test your UDx container](#testing-the-container), you can develop UDx
 The following command passes a file containing [environment variables](#environment-variables):
 
 ```shell
-$ VSDK_ENV=env-vars vsdk-make
+$ VSDK_ENV=env-vars-file vsdk-make
 ```
 
 ## Mounting additional files 
@@ -147,7 +146,7 @@ $ VSDK_MOUNT='/usr/share/lib /usr/share/toolB' make test
 
 ## Host and container filesystem views
 
-By default, the UDx container contains the following directories:
+By default, the UDx container has the following directories:
 - `/bin`
 - `/lib`
 - `/opt/vertica`
@@ -178,7 +177,7 @@ To make your UDx available to the test Vertica server, start the server in your 
 
 In addition to the `vsdk-make` and `vsdk-g++` tools, there is a `vsdk-vertica` command that creates a scratch Vertica server so you can test your UDx.
 
-The UDx container itself is not writable, so it creates and mounts a Docker volume called `verticasdk-data`. It also mounts the current working directory and your home directory in the container using the same names those directories have on the host machine. In addition, `vsdk-vertica` understands the `VSDK_MOUNT` and `VSDK_ENV` environment variables described in [environment variables](#environment-variables).
+The UDx container itself is not writable, so it creates and mounts a Docker volume called `verticasdk-data`. It also mounts the current working directory and your home directory in the container using the same names those directories have on the host machine. In addition, `vsdk-vertica` understands the `VSDK_MOUNT` and `VSDK_ENV` [environment variables](#environment-variables).
 
 
 ## Fetching the test Vertica server startup log
@@ -219,16 +218,16 @@ using
     vsql -p 11233 -U dbadmin
 ```
 
-Outside the VSDK container the Vertica port is mapped to a non-standard port (in this case, `11233`).  The `-U dbadmin` connects to Vertica as the dbadmin user.  The database does not yet have any other users defined.  The dbadmin user has a blank password in this container's database, and has permission to manipulate UDx libraries in the container's database.
+Outside the VSDK container, the Vertica port is mapped to the non-standard port `11233`. The `-U dbadmin` connects to Vertica as the DBADMIN user. The database does not have any other users defined. DBADMIN has a blank password in this container's database, and has permission to manipulate UDx libraries in the container's database.
 
 ## Stopping and removing the test Vertica server
 
-When you are done using the container, use `docker stop` to stop it:
+Stop the container with `docker stop`:
 
 ```shell
 docker stop verticasdk
 ```
-Use `docker rm` to remove it:
+Remove the container with `docker rm`:
 
 ```shell
 docker rm verticasdk
@@ -254,7 +253,7 @@ For additional details about working with UDx libraries, see [User-Defined Exten
 
 # Testing the container
 
-> **NOTE**: This section describes testing the UDx container after you modified the container with any of the tools in this repository. For testing your UDx, see [Testing your UDx](#testing-your-udx).
+> **NOTE**: This section describes how to test a UDx container that was modified with the tools in this repository.
 
 The `make test` target calls a few `vsdk-*` scripts to test that your container was built correctly. Then, it mounts the following directories in the UDx container filesystem to replicate your local development environment:
 - `/home/<user-name>`
@@ -269,4 +268,4 @@ Run `make test` with the `TARGET` environment variable:
 ```shell
 $ make test TARGET=deb
 ```
-> **NOTE**: The scripts need to know the tag for the container, which is derived from the VERTICA_VERSION environment variable.  If you have a canonically-named RPM or DEB, the Makefile knows how to extract the VERTICA_VERSION from the filename, otherwise you will have to specify it, just as you did when you created the container.
+> **NOTE**: The scripts require the container tag, which is derived from the `VERTICA_VERSION` environment variable. If you have a canonically-named RPM or DEB file, the `Makefile` extracts the `VERTICA_VERSION` from the filename. Otherwise you must specify the tag the same way that you did when you created the container.

--- a/UDx-container/README.md
+++ b/UDx-container/README.md
@@ -20,30 +20,32 @@ Container techology provides the freedom to run environments independently of th
 
 Vertica provides a Dockerfile for different distributions so that you can create an containerized development environment that matches your production environment.
 
-## Vertica:
+## Vertica
+
 Vertica tests the following versions, but the contents of this repository might work with eariler versions:
-- 10.x
-- 11.x
 - 12.x
+- 11.x
+- 10.x
 
 ## CentOS
 - 7.9
 
 ## Ubuntu
-- 18.04
 - 20.04
+- 18.04
+
 
 # Overview
 
-The Vertica UDx container packages the binaries, libraries, and compilers required to create C++ Vertica UDx extensions. Use this repository with your Vertica binary to develop UDxs on any host system that meets the [Prerequisites](#prerequisites).
+The Vertica UDx container packages the binaries, libraries, and compilers required to create C++ Vertica UDx extensions. Use this repository with your Vertica binary to develop UDxs on any host system that meets the [prerequisites](#prerequisites).
 
 In addition, this repository provides `vsdk-*` commmand line tools to simplify the development process. You can develop UDxs on your host machine, compile them within the UDx container, and then save the object files on your host machine to load into Vertica.
 
-Of special note is the `vsdk-vertica` command which launches a container with a Vertica executing within it.  You can use this container to load and test your UDx.
+Of special note is the `vsdk-vertica` command which launches a container with a running Vertica instance. You can use this container to load and test your UDx.
 
 # Building the UDx container
 
-Use the repository `makefile` to build your container. The makefile requires that you store a Vertica RPM or DEB file in the top level of the UDx-container directory of your cloned repository. The container inherits the privileges and user ID from the user executing the container.
+Use the repository [Makefile](Makefile) to build your container. The Makefile requires that you store a Vertica RPM or DEB file in the top level of the UDx-container directory of your cloned repository. The container inherits the privileges and user ID from the user executing the container.
 
 ## Build variables
 
@@ -51,16 +53,16 @@ You can include build variables in the build process to customize the container.
 
 | Name                      | Definition |
 |---------------------------|------------|
-| OSTAG | The container operating system distribution, either `centos` or `ubuntu`. This variable is required to build a container that runs an OS that is different from the host OS. |
-| PACKAGE | When there is more than one Vertica RPM or DEB file in the top-level directory, this variable specifies which file to use in the build process. |
-| TARGET | Required. The file type (`rpm` or `deb`) of the Vertica binary that you use in the build process. |
-| VERTICA_VERSION | The version number of the Vertica binary used in the build process. This value is optional for a [canonically-named Vertica binary](#building-with-a-canonically-named-vertica-binary).<br> You can use this variable to build containers for different Vertica versions. |
+| `OSTAG` | The container operating system distribution, either `centos` or `ubuntu`. This variable is required to build a container that runs an OS that is different from the host OS. |
+| `PACKAGE` | When there is more than one Vertica RPM or DEB file in the top-level directory, this variable specifies which file to use in the build process. |
+| `TARGET` | Required. The file type (`rpm` or `deb`) of the Vertica binary that you use in the build process. |
+| `VERTICA_VERSION` | The version number of the Vertica binary used in the build process. This value is optional for a [canonically-named Vertica binary](#building-with-a-canonically-named-vertica-binary).<br> You can use this variable to build containers for different Vertica versions. |
 
-For example, you might build multiple containers to develop UDxs for multiple Vertica versions. To help distinguish between containers, define `OSTAG` and `VERTICA_VERSION` in the build command. If you set `OSTAG=centos` and `VERTICA_VERSION=11.0.0-0`, the full container specification is `verticasdk:centos-11.0.0-0`.
+You might build multiple containers to develop UDxs for multiple Vertica versions. To help distinguish between containers, define `OSTAG` and `VERTICA_VERSION` in the build command. If you set `OSTAG=centos` and `VERTICA_VERSION=11.0.0-0`, the full container specification is `verticasdk:centos-11.0.0-0`.
 
 ## Building with a canonically-named Vertica binary
 
-The build process requires the Vertica version. The `makefile` can extract this information automatically from a canonically-named RPM or DEB file in one of the following formats:
+The build process requires the Vertica version. The `Makefile` can extract this information automatically from a canonically-named RPM or DEB file in one of the following formats:
 
 ```shell
 $ vertica-10.1.1-5.x86_64.RHEL6.rpm
@@ -70,7 +72,7 @@ $ vertica-10.1.1-5.x86_64.RHEL6.rpm
 $ vertica_10.0.1-5_amd64.deb
 ```
 
-The `makefile` extracts the Vertica version (10.1.1-5) and the OS distribution version (RHEL 6). If the Vertica binary uses this format, run `make` with the `TARGET` variable to build the container. For example, the following command builds a UDx container with a canonically-named RPM file:
+The `Makefile` extracts the Vertica version (10.1.1-5) and the OS distribution version (RHEL 6). If the Vertica binary uses this format, run `make` with the `TARGET` variable to build the container. For example, the following command builds a UDx container with a canonically-named RPM file:
 
 ```shell
 $ make TARGET=rpm
@@ -90,10 +92,10 @@ This repository provides `vsdk-*` scripts to help you test and compile your UDx 
 
 | Script&nbsp;name | Description |
 |-------------|-------------|
-| vsdk-bash | Opens a bash shell in the UDx container. This script is useful for debugging. |
-| vsdk-cp | Invokes `cp` inside the UDx container. This is a helper script used in the `make test` command, and included because the UDx container is not writable and you might need to copy UDx files to your host for editing. |
-| vsdk-g++ | Executes the g++ compiler in the UDx container. |
-| vsdk-make | Executes `make` in the current working directory in the UDx container. This allows you to develop UDxs locally and compile them with the tools available in the UDx container. |
+| `vsdk-bash` | Opens a bash shell in the UDx container. This script is useful for debugging. |
+| `vsdk-cp` | Invokes `cp` inside the UDx container. This is a helper script used in the `make test` command, and included because the UDx container is not writable and you might need to copy UDx files to your host for editing. |
+| `vsdk-g++` | Executes the g++ compiler in the UDx container. |
+| `vsdk-make` | Executes `make` in the current working directory in the UDx container. This allows you to develop UDxs locally and compile them with the tools available in the UDx container. |
 
 `vsdk-make` is the script that you will probably
 use the most often. It behaves exactly like `make`, but it compiles your files in the development environment mounted in the UDx container.
@@ -110,14 +112,14 @@ Use environment variables to provide additional information to the `vsdk-*` comm
 
 | Environment&nbsp;Variable | Definition |
 |---------------------------|------------|
-| OSTAG | The container operating system distribution, either `centos` or `ubuntu`. This variable is if you use a container that runs an OS that is different from the host OS. If you do not define this variable, `vsdk-make` reads `/etc/os-release` to determine the OS. |
-| VERTICA_VERSION | The version number of the Vertica binary used in the build process. |
-| VSDK_ENV | Optional file that defines environment variables for `vsdk-*` commands that run in the container. For formatting details, see [Declare default environment variables in file](https://docs.docker.com/compose/env-file/) in the Docker documentation.|
-| VSDK_MOUNT | A list of one or more directories that you want to mount in the UDx container filesystem. To mount multiple directories, separate each path with a space. For additional details, see [Mounting additional files](#mounting-additional-files). |
+| `OSTAG` | The container operating system distribution, either `centos` or `ubuntu`. This variable is if you use a container that runs an OS that is different from the host OS. If you do not define this variable, `vsdk-make` reads `/etc/os-release` to determine the OS. |
+| `VERTICA_VERSION` | The version number of the Vertica binary used in the build process. |
+| `VSDK_ENV` | Optional file that defines environment variables for `vsdk-*` commands that run in the container. For formatting details, see [Declare default environment variables in file](https://docs.docker.com/compose/env-file/) in the Docker documentation.|
+| `VSDK_MOUNT` | A list of one or more directories that you want to mount in the UDx container filesystem. To mount multiple directories, separate each path with a space. For additional details, see [Mounting additional files](#mounting-additional-files). |
 
 ## Compiling UDxs
 
-After you [test your UDx container](#testing-the-container), you can develop UDxs in the current working directory on the host machine and compile them in the UDx container. Use the `vsdk-make` script to execute your makefile and compile your UDx. In a new environment, `vsdk-make` mounts the same directories as the `make test` command.
+After you [test your UDx container](#testing-the-container), you can develop UDxs in the current working directory on the host machine and compile them in the UDx container. Use the `vsdk-make` script to execute your Makefile and compile your UDx. In a new environment, `vsdk-make` mounts the same directories as the `make test` command.
 
 The following command passes a file containing [environment variables](#environment-variables):
 
@@ -165,25 +167,23 @@ In the previous diagram:
    $ VSDK_MOUNT='/usr/share/lib /usr/share/vtoolB' vsdk-make
    ```
 
-# Loading the UDx into a test Vertica server
+# Load the UDx into a test Vertica server
 
-## Making your UDx accessible to the test Vertica server
+## Make the UDx available to the test Vertica server
 
-Start the server in your UDx working directory. This provides the test Vertica server container a path to your UDx working directory when it starts and so that it can mount its current working directory. The Vertica in the container runs as `dbadmin`.
+To make your UDx available to the test Vertica server, start the server in your UDx working directory. This provides the test Vertica server container a path to your UDx working directory when it starts so it can mount its current working directory. The Vertica in the container runs as `dbadmin`.
 
 
 ## Starting the test Vertica server
 
-In addition to the tools such as `vsdk-make` and `vsdk-g++`, there is a `vsdk-vertica` command that creates a scratch Vertica server so you can test your UDx.
+In addition to the `vsdk-make` and `vsdk-g++` tools, there is a `vsdk-vertica` command that creates a scratch Vertica server so you can test your UDx.
 
 The UDx container itself is not writable, so it creates and mounts a Docker volume called `verticasdk-data`. It also mounts the current working directory and your home directory in the container using the same names those directories have on the host machine. In addition, `vsdk-vertica` understands the `VSDK_MOUNT` and `VSDK_ENV` environment variables described in [environment variables](#environment-variables).
 
 
 ## Fetching the test Vertica server startup log
 
-`vsdk-vertica` launches a server that runs in the background in a container named `verticasdk`.
-
-The command, when run, outputs the following message:
+`vsdk-vertica` launches a server that runs in the background in a container named `verticasdk`. The command outputs the following message:
 
 ```shell
 ./vsdk-vertica
@@ -205,7 +205,7 @@ If executing inside a VWasm container (where you did your Wasm development),
 just 'vsql' should suffice
 ```
 
-As noted, you can read the container log using the `docker logs` command:
+You can read the container log using the `docker logs` command:
 
 ```shell
 docker logs verticasdk
@@ -269,4 +269,4 @@ Run `make test` with the `TARGET` environment variable:
 ```shell
 $ make test TARGET=deb
 ```
-> **NOTE**: The scripts need to know the tag for the container, which is derived from the VERTICA_VERSION environment variable.  If you have a canonically-named RPM or DEB, the makefile knows how to extract the VERTICA_VERSION from the filename, otherwise you will have to specify it, just as you did when you created the container.
+> **NOTE**: The scripts need to know the tag for the container, which is derived from the VERTICA_VERSION environment variable.  If you have a canonically-named RPM or DEB, the Makefile knows how to extract the VERTICA_VERSION from the filename, otherwise you will have to specify it, just as you did when you created the container.

--- a/one-node-ce/README.md
+++ b/one-node-ce/README.md
@@ -19,7 +19,7 @@ Container techology provides the freedom to run environments independently of th
 
 Vertica provides a Dockerfile for different distributions so that you can create an containerized environment that you are the most comfortable with. This is helpful if you need to access a container shell to perform tasks, such as administering the database with [admintools](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/AdminTools/WritingAdministrationToolsScripts.htm).
 
-## Vertica:
+## Vertica
 - 12.x
 - 11.x
 - 10.x
@@ -94,7 +94,7 @@ $ make IMAGE_NAME=one-node-ce TAG=latest VERTICA_DB_USER=vertica VERTICA_DB_UID=
 ```
 ## Test the image
 
-After you [build the image](#build-the-image), test it with the [run_tests.sh](./run-tests.sh) script. You can use the `make test` target to run `run_tests.sh`, or you can run the script directly
+After you [build the image](#build-the-image), test it with the [run_tests.sh](./run-tests.sh) script. You can use the `make test` target to run `run_tests.sh`, or you can run the script directly.
 
 > **IMPORTANT**: The script uses the Vertica port number `5433`. You must stop any existing Vertica server on your test system before you test your container.
 
@@ -183,7 +183,7 @@ The following table describes environment variables that you can configure at ru
 | :--------------------| :-----------|
 | `APP_DB_USER` | Name of a database user, in addition to `VERTICA_DB_USER`. This user is created only when this variable is set. By default, `APP_DB_USER` is assigned [pseudosuperuser](https://www.vertica.com/docs/latest/HTML/Content/Authoring/AdministratorsGuide/DBUsersAndPrivileges/Roles/PSEUDOSUPERUSERRole.htm) privileges. |
 | `APP_DB_PASSWORD` | Password for `APP_DB_USER`. If this is omitted, the password is empty. |
-| `TZ`: "${VERTICA_CUSTOM_TZ:-Europe/Prague}" | The database time zone. Setting `VERTICA_CUSTOM_TZ` overrides the time zone set in your environment.<br><br>**IMPORTANT**: Vertica does not contain all time zones. Each Dockerfile contains a commented-out workaround solution that begins "Link OS time zones". Uncomment the workaround to use time zones.<br> |
+| `TZ` | The database time zone. Setting `TZ` overrides the time zone set in your environment.<br><br>**IMPORTANT**: Vertica does not contain all time zones. Each Dockerfile contains a commented-out workaround solution that begins "Link OS time zones". Uncomment the workaround to use time zones.<br> |
 | `DEBUG_FAILING_STARTUP` | For development purposes. When you set the value to `y`, the entrypoint script does not end in case of failure, so you can investigate any failures. |
 
 ## Custom scripts

--- a/one-node-ce/README.md
+++ b/one-node-ce/README.md
@@ -188,9 +188,7 @@ The following table describes environment variables that you can configure at ru
 
 ## Custom scripts
 
-The `docker-entrypoint.sh` script can run custom scripts during startup. You must store the scripts in a local directory named `.docker-entrypoint-initdb.d` and mount it in the container filesystem in `/docker-entrypoint-initdb.d/`. Scripts are executed in lexicographical order.
-
-Supported extensions include:
+The `docker-entrypoint.sh` script can run custom scripts during startup. You must store the scripts in a local directory named `.docker-entrypoint-initdb.d` and mount it in the container filesystem in `/docker-entrypoint-initdb.d/`. Scripts are executed in lexicographical order. Supported extensions include:
 - `sql`: SQL commands executed with vsql
 - `sh`: Shell scripts
 
@@ -226,7 +224,7 @@ $ ./run-shell-in-container.sh -n vertica_ce
 
 ## Access with `docker exec`
 
-Access a shell in the container with `docker exec`. `docker exec` requires that you provide the container name:
+Access a shell in the container with `docker exec`. `docker exec` requires the container name:
 
 ```shell
 $ docker exec -it <container name> bash -l


### PR DESCRIPTION
Minor edits to the top-level README and one-node-ce README. More substantial copy edits to the UDx README to make them consistent with , but no content changes

CE README:
- Updated TZ environment variable. Looks like this was previously named VERTICA_CUSTOM_TZ, but that is not in the entrypoint script

UDx README:
- moved testing udx container material directly after building udx container
- updated section titles
