### PR TITLE
Allow the RPM to be in a different directory

### DIFF
--- a/UDx-container/Makefile
+++ b/UDx-container/Makefile
@@ -106,9 +106,12 @@ CONTAINER_NAME = vertica/verticasdk
 export CONTAINER_TAG = $(CONTAINER_NAME):$(CONTAINER_OS)-v$(VERTICA_VERSION)
 
 build: display Dockerfile_$(TARGET_U) ${SUFFIX} ## Build container given PACKAGE=<file>
+	# link/copy rpm file to local directory and clean it up when done
+	@ln $(PACKAGE) vertica.$$$$.rpm 2>/dev/null || cp $(VERTICA_RPM) vertica.$$$$.rpm || exit 1 \
+	trap "rm -f vertica.$$$$.rpm" EXIT INT; \
 	docker build \
 		-f Dockerfile_$(TARGET_U)${SUFFIX} \
-		--build-arg $(TARGET_U)=$(PACKAGE) \
+		--build-arg $(TARGET_U)=vertica.$$$$.rpm \
 		--build-arg os_version=$(CONTAINER_OS_VERSION) \
 		--build-arg vertica_version=$(VERTICA_VERSION) \
 		--tag $(CONTAINER_TAG) .


### PR DESCRIPTION
Docker requires the install files to be in the current working directory.  This change will create a hardlink to the RPM file , but if the RPM is on a different device, it falls back to copying the rpm to the current working directory.  Then, after docker is done with it, the newly created link/copy is deleted.  Interrupting the process should still remove the file if it can.