### PR TITLE
Update almalinux version to 8.6

### DIFF
--- a/one-node-ce/Dockerfile_CentOS
+++ b/one-node-ce/Dockerfile_CentOS
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##############################################################################
-ARG os_version="8"
+ARG os_version="8.6"
 
 FROM almalinux:${os_version} as builder
 

--- a/one-node-ce/Makefile
+++ b/one-node-ce/Makefile
@@ -67,7 +67,7 @@ $(error "Choice of OS_TYPE Ubuntu not consistent with choice of .rpm file for VE
 	endif
 else
 	OS_TYPE = CentOS 
-	OS_VERSION ?= 8
+	OS_VERSION ?= 8.6
 	ifeq ($(TAG),latest)
 		VERTICA_PACKAGE ?= vertica-x86_64.RHEL6.latest.rpm
 	else


### PR DESCRIPTION
Changed almalinux version to 8.6 and now we can successfully start the db in the one-node-ce container.