### PR TITLE
Replace centos with almalinux

### DIFF
--- a/one-node-ce/Dockerfile_AlmaLinux
+++ b/one-node-ce/Dockerfile_AlmaLinux
@@ -238,6 +238,6 @@ EXPOSE 5433
 EXPOSE 5444
 
 LABEL image_name="vertica_db"
-LABEL os_family="centos"
+LABEL os_family="almalinux"
 LABEL os_version="$os_version"
 LABEL maintainer="K8 Team"

--- a/one-node-ce/Makefile
+++ b/one-node-ce/Makefile
@@ -44,7 +44,7 @@ ifeq ($(origin OS_TYPE), undefined)
 		ifeq (.deb, $(findstring .deb, $(VERTICA_PACKAGE)))
 			OS_TYPE=Ubuntu
 		else
-			OS_TYPE=CentOS
+			OS_TYPE=AlmaLinux
 		endif
 	else
 # can't indent because then it looks like part of a recipe
@@ -53,7 +53,7 @@ $(error "Need one of OS_TYPE or VERTICA_PACKAGE to be defined")
 endif
 
 
-# This step ensures that the script builds CentOS7.9.2009 in default.
+# This step ensures that the script builds AlmaLinux-8.6 in default.
 # Check for Image OS and assign default values to OS_VERSION, if not defined.
 ifeq ($(OS_TYPE),Ubuntu)
 	OS_VERSION ?= 18.04
@@ -66,7 +66,7 @@ ifeq ($(OS_TYPE),Ubuntu)
 $(error "Choice of OS_TYPE Ubuntu not consistent with choice of .rpm file for VERTICA_PACKAGE")
 	endif
 else
-	OS_TYPE = CentOS 
+	OS_TYPE = AlmaLinux
 	OS_VERSION ?= 8.6
 	ifeq ($(TAG),latest)
 		VERTICA_PACKAGE ?= vertica-x86_64.RHEL6.latest.rpm
@@ -74,7 +74,7 @@ else
 		VERTICA_PACKAGE ?= vertica-$(TAG).x86_64.RHEL6.rpm
 	endif
 	ifeq (.deb, $(findstring .deb, $(VERTICA_PACKAGE)))
-$(error "Choice of OS_TYPE CentOS not consistent with choice of .deb file for VERTICA_PACKAGE")
+$(error "Choice of OS_TYPE AlmaLinux not consistent with choice of .deb file for VERTICA_PACKAGE")
 	endif
 endif
 
@@ -105,8 +105,8 @@ display:
 	$(info  Defined Parameters)
 	$(info    - Image Name  ='$(IMAGE_NAME)', Default:vertica-ce)
 	$(info    - Tag         ='$(TAG)', Default:latest)
-	$(info    - OS Type     ='$(OS_TYPE)', Default:CentOS)
-	$(info    - OS Version  ='$(OS_VERSION)', Default:7.9.2009)
+	$(info    - OS Type     ='$(OS_TYPE)', Default:AlmaLinux)
+	$(info    - OS Version  ='$(OS_VERSION)', Default:8.6)
 	$(info    - DB User     ='$(VERTICA_DB_USER)', Default if blank: dbadmin)
 	$(info    - DB Group    ='$(VERTICA_DB_GROUP)', Default if blank: verticadba)
 	$(info    - DB Name     ='$(VERTICA_DB_NAME)', Default if blank: :VMart)

--- a/one-node-ce/README.md
+++ b/one-node-ce/README.md
@@ -24,15 +24,14 @@ Vertica provides a Dockerfile for different distributions so that you can create
 - 11.x
 - 10.x
 
-## CentOS
-- 8.3
-- 7.9
+## AlmaLinux
+- 8.6
 
 ## Ubuntu
 - 20.04
 - 18.04
 
-Vertica tests the CentOS containers most thoroughly. Vertica provides the [Dockerfile_Ubuntu](./Dockerfile_Ubuntu) for users that have only a Vertica DEB file. You can adapt that Dockerfile for recent versions of Debian.
+Vertica tests the AlmaLinux containers most thoroughly. Vertica provides the [Dockerfile_Ubuntu](./Dockerfile_Ubuntu) for users that have only a Vertica DEB file. You can adapt that Dockerfile for recent versions of Debian.
 
 # How to use this image
 
@@ -52,9 +51,9 @@ The following table describes base image properties that you can customize with 
 | :--------------------| :-----------| :--------------|
 | `TAG`          | Required. Image tag that represents the Vertica version. | `latest` |
 | `IMAGE_NAME`   | Required. Image name. | `vertica-ce` |
-| `OS_TYPE`      | Required. Operating system distribution.  | `CentOS` | 
-| `OS_VERSION`   | Required. Operatoring system versions. | CentOS: `7.9.2009`<br> Ubuntu: `18.04` | 
-| `VERTICA_PACKAGE` | Name of the RPM or DEB file. | CentOS: `vertica-x86_64.RHEL6.latest.rpm`<br>Ubuntu: `vertica.latest.deb` |
+| `OS_TYPE`      | Required. Operating system distribution.  | `AlmaLinux` | 
+| `OS_VERSION`   | Required. Operatoring system versions. | AlmaLinux: `8.6`<br> Ubuntu: `18.04` | 
+| `VERTICA_PACKAGE` | Name of the RPM or DEB file. | AlmaLinux: `vertica-x86_64.RHEL6.latest.rpm`<br>Ubuntu: `vertica.latest.deb` |
 
 > **Note**: If you do not specify `VERTICA_PACKAGE`, and `TAG` is not set to `latest`, then the `TAG` must be the Vertica version because it is used to construct the version portion of the `VERTICA_PACKAGE` name.
 


### PR DESCRIPTION
We now use almalinux instead of centos for one-node CE IMAGE, this is to update parts of the doc where centos was still mentioned.