### PR TITLE
make rpm portable

### DIFF
--- a/one-node-ce/Dockerfile_AlmaLinux
+++ b/one-node-ce/Dockerfile_AlmaLinux
@@ -21,7 +21,7 @@ ENV VERTICA_VOLUME_DIR="/data"
 ENV VERTICA_DATA_DIR="${VERTICA_VOLUME_DIR}/vertica"
 ENV VMART_DIR="${VERTICA_OPT_DIR}/examples/VMart_Schema"
 
-ARG vertica_package="vertica-x86_64.RHEL6.latest.rpm"
+ARG vertica_package
 ARG vertica_db_user="dbadmin"
 ARG vertica_db_group="verticadba"
 ARG vertica_db_name="VMart"

--- a/one-node-ce/Makefile
+++ b/one-node-ce/Makefile
@@ -69,9 +69,9 @@ else
 	OS_TYPE = AlmaLinux
 	OS_VERSION ?= 8.6
 	ifeq ($(TAG),latest)
-		VERTICA_PACKAGE ?= $(basename $(notdir $(wildcard packages/vertica*.rpm)))
+		VERTICA_PACKAGE ?= $(notdir $(wildcard packages/vertica*.rpm))
 	else
-		VERTICA_PACKAGE ?= $(basename $(notdir $(wildcard packages/vertica-$(TAG)*.rpm)))
+		VERTICA_PACKAGE ?= $(notdir $(wildcard packages/vertica-$(TAG)*.rpm))
 	endif
 	ifeq (.deb, $(findstring .deb, $(VERTICA_PACKAGE)))
 $(error "Choice of OS_TYPE AlmaLinux not consistent with choice of .deb file for VERTICA_PACKAGE")

--- a/one-node-ce/Makefile
+++ b/one-node-ce/Makefile
@@ -69,9 +69,9 @@ else
 	OS_TYPE = AlmaLinux
 	OS_VERSION ?= 8.6
 	ifeq ($(TAG),latest)
-		VERTICA_PACKAGE ?= vertica-x86_64.RHEL6.latest.rpm
+		VERTICA_PACKAGE ?= $(basename $(notdir $(wildcard packages/vertica*.rpm)))
 	else
-		VERTICA_PACKAGE ?= vertica-$(TAG).x86_64.RHEL6.rpm
+		VERTICA_PACKAGE ?= $(basename $(notdir $(wildcard packages/vertica-$(TAG)*.rpm)))
 	endif
 	ifeq (.deb, $(findstring .deb, $(VERTICA_PACKAGE)))
 $(error "Choice of OS_TYPE AlmaLinux not consistent with choice of .deb file for VERTICA_PACKAGE")


### PR DESCRIPTION
Make finding rpm more portable with new RHEL8 naming changes