### PR TITLE
Install ps command in vertica-ce container

### DIFF
--- a/one-node-ce/Dockerfile_AlmaLinux
+++ b/one-node-ce/Dockerfile_AlmaLinux
@@ -193,6 +193,7 @@ RUN set -x \
         sysstat \
         wget \
         which \
+        procps-ng \
  # Allow passwordless sudo access from dbadmin
      && echo "$vertica_db_user ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers \
      # docker daemons versions < 19.03 don't preserve ownership on COPY --from


### PR DESCRIPTION
vertica-ce failed due to ps is missing in the almanlinux version of the image. This adds the package in the Dockerfile.